### PR TITLE
feat: Phase N1-N3 — 節點式視覺化設定系統核心 + 渲染設定接入

### DIFF
--- a/Block Reality/api/src/main/java/com/blockreality/api/client/render/BRRenderSettings.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/client/render/BRRenderSettings.java
@@ -3,6 +3,10 @@ package com.blockreality.api.client.render;
 import com.blockreality.api.client.render.pipeline.BRRenderTier;
 import com.blockreality.api.client.render.rt.BRVulkanDevice;
 import com.blockreality.api.client.render.rt.BRVulkanRT;
+import com.blockreality.api.node.EvaluateScheduler;
+import com.blockreality.api.node.NodeGraph;
+import com.blockreality.api.node.NodeGraphIO;
+import com.blockreality.api.node.binder.RenderConfigBinder;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import org.slf4j.Logger;
@@ -97,7 +101,11 @@ public final class BRRenderSettings {
     private static float renderScale = 1.0f;       // 0.5, 0.75, 1.0, 1.5, 2.0
 
     private static Path settingsFile;
+    private static Path graphDir;
     private static boolean initialized = false;
+
+    // ─── 節點圖整合 ──────────────────────────────────
+    private static boolean nodeGraphActive = false;
 
     // ═══════════════════════════════════════════════════════
     //  初始化
@@ -105,14 +113,65 @@ public final class BRRenderSettings {
 
     public static void init(Path configDir) {
         settingsFile = configDir.resolve("blockreality").resolve("render_settings.properties");
+        graphDir = configDir.resolve("blockreality").resolve("node_graphs");
         load();
+
+        // 初始化節點圖系統
+        try {
+            java.nio.file.Files.createDirectories(graphDir);
+            EvaluateScheduler.init();
+            RenderConfigBinder.init();
+
+            // 嘗試載入使用者保存的節點圖，或建立預設
+            Path savedGraph = graphDir.resolve("active_render.json");
+            NodeGraph graph;
+            if (Files.exists(savedGraph)) {
+                graph = NodeGraphIO.loadFromFile(savedGraph);
+                LOG.info("[Settings] 載入使用者節點圖: {}", savedGraph);
+            } else {
+                // 根據當前風格建立預設節點圖
+                graph = createPresetGraph(currentStyle);
+                LOG.info("[Settings] 建立預設節點圖: {}", currentStyle.displayName);
+            }
+
+            EvaluateScheduler.setActiveGraph(graph);
+            RenderConfigBinder.pullFromSettings(graph);
+            nodeGraphActive = true;
+        } catch (Exception e) {
+            LOG.warn("[Settings] 節點圖初始化失敗，使用 properties fallback: {}", e.getMessage());
+            nodeGraphActive = false;
+        }
+
         initialized = true;
-        LOG.info("[Settings] 渲染設定載入完成 — 風格: {}, Tier: {}",
-            currentStyle.displayName, BRRenderTier.getCurrentTier().name);
+        LOG.info("[Settings] 渲染設定載入完成 — 風格: {}, 節點圖: {}",
+            currentStyle.displayName, nodeGraphActive ? "啟用" : "停用");
+    }
+
+    private static NodeGraph createPresetGraph(RenderStyle style) {
+        return switch (style) {
+            case CINEMA -> NodeGraphIO.createUltraPreset();
+            case BALANCED -> NodeGraphIO.createHighPreset();
+            case PERFORMANCE -> NodeGraphIO.createLowPreset();
+            case MINIMAL -> NodeGraphIO.createPotatoPreset();
+            default -> NodeGraphIO.createMediumPreset();
+        };
     }
 
     public static void cleanup() {
         save();
+        // 保存節點圖
+        if (nodeGraphActive && graphDir != null && EvaluateScheduler.getActiveGraph() != null) {
+            try {
+                Path savedGraph = graphDir.resolve("active_render.json");
+                NodeGraphIO.saveToFile(EvaluateScheduler.getActiveGraph(), savedGraph);
+                LOG.info("[Settings] 節點圖已保存: {}", savedGraph);
+            } catch (Exception e) {
+                LOG.warn("[Settings] 節點圖保存失敗: {}", e.getMessage());
+            }
+        }
+        EvaluateScheduler.cleanup();
+        RenderConfigBinder.cleanup();
+        nodeGraphActive = false;
         initialized = false;
     }
 
@@ -469,4 +528,38 @@ public final class BRRenderSettings {
     private static void appendEffect(StringBuilder sb, String name, boolean on) {
         sb.append(on ? "§a" : "§c").append(name).append(on ? "✓" : "✗").append(" ");
     }
+
+    // ═══════════════════════════════════════════════════════
+    //  節點圖整合 API
+    // ═════════════���═════════════════════════════════════════
+
+    /** 節點圖是否啟用 */
+    public static boolean isNodeGraphActive() { return nodeGraphActive; }
+
+    /** 取得活躍節點圖 */
+    public static NodeGraph getActiveNodeGraph() {
+        return EvaluateScheduler.getActiveGraph();
+    }
+
+    /**
+     * 從節點圖同步設定（每幀呼叫）。
+     * 節點圖評估後，RenderConfigBinder 推送值到 BRRenderSettings。
+     */
+    public static void syncFromNodeGraph() {
+        if (!nodeGraphActive || EvaluateScheduler.getActiveGraph() == null) return;
+        RenderConfigBinder.pushToSettings(EvaluateScheduler.getActiveGraph());
+    }
+
+    /**
+     * 切換風格時同步更新節點圖。
+     */
+    public static void applyStyleToNodeGraph(RenderStyle style) {
+        if (!nodeGraphActive) return;
+        NodeGraph graph = createPresetGraph(style);
+        EvaluateScheduler.setActiveGraph(graph);
+        RenderConfigBinder.pullFromSettings(graph);
+    }
+
+    /** 取得節點圖保存目錄 */
+    public static Path getGraphDir() { return graphDir; }
 }

--- a/Block Reality/api/src/main/java/com/blockreality/api/client/render/pipeline/BRRenderPipeline.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/client/render/pipeline/BRRenderPipeline.java
@@ -556,7 +556,13 @@ public final class BRRenderPipeline {
                 BRShaderLOD.recordFrameTime(frameTimeMs);
             }
 
-            // 非同步任務排程：每幀處理佇列中的延遲任務
+            // 節點圖評估（每幀 tick — 惰性評估僅處理 dirty 節點）
+            if (BRRenderSettings.isNodeGraphActive()) {
+                com.blockreality.api.node.EvaluateScheduler.tick();
+                BRRenderSettings.syncFromNodeGraph();
+            }
+
+            // 非同步任務排程：每幀處理佇列中的���遲任務
             BRAsyncComputeScheduler.processTasks();
 
             // 除錯覆蓋層（F3+B 切換）

--- a/Block Reality/api/src/main/java/com/blockreality/api/node/BRNode.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/node/BRNode.java
@@ -1,0 +1,228 @@
+package com.blockreality.api.node;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Abstract base class for every node in a Block Reality node graph.
+ * Subclasses declare their ports in the constructor and implement {@link #evaluate()}.
+ */
+public abstract class BRNode {
+    private final String nodeId;
+    private String displayName;
+    private String category;   // "render", "material", "physics", "tool", "export"
+    private int color;         // category color (hex)
+
+    // Canvas position (used by the editor UI)
+    private float posX;
+    private float posY;
+    private boolean collapsed;
+
+    // Ports
+    private final List<NodePort> inputs = new ArrayList<>();
+    private final List<NodePort> outputs = new ArrayList<>();
+
+    // Evaluation state
+    private boolean dirty = true;
+    private boolean enabled = true;
+    private long lastEvalTimeNs;
+
+    protected BRNode(String displayName, String category, int color) {
+        this.nodeId = UUID.randomUUID().toString();
+        this.displayName = displayName;
+        this.category = category;
+        this.color = color;
+    }
+
+    // ---- Port creation helpers (call in subclass constructors) ----
+
+    protected NodePort addInput(String name, PortType type, Object defaultValue) {
+        NodePort port = new NodePort(name, type, true, this, defaultValue);
+        inputs.add(port);
+        return port;
+    }
+
+    protected NodePort addOutput(String name, PortType type) {
+        NodePort port = new NodePort(name, type, false, this, null);
+        outputs.add(port);
+        return port;
+    }
+
+    // ---- Abstract evaluation ----
+
+    /**
+     * Compute output values from the current input values.
+     * Called by the graph scheduler when this node is dirty.
+     */
+    public abstract void evaluate();
+
+    // ---- Convenience: read input values ----
+
+    protected float getFloat(String portName) {
+        NodePort p = getInput(portName);
+        if (p == null) return 0.0f;
+        Object v = p.getValue();
+        if (v instanceof Number) return ((Number) v).floatValue();
+        return 0.0f;
+    }
+
+    protected int getInt(String portName) {
+        NodePort p = getInput(portName);
+        if (p == null) return 0;
+        Object v = p.getValue();
+        if (v instanceof Number) return ((Number) v).intValue();
+        return 0;
+    }
+
+    protected boolean getBool(String portName) {
+        NodePort p = getInput(portName);
+        if (p == null) return false;
+        Object v = p.getValue();
+        if (v instanceof Boolean) return (Boolean) v;
+        if (v instanceof Number) return ((Number) v).intValue() != 0;
+        return false;
+    }
+
+    // ---- Convenience: set output values ----
+
+    protected void setOutput(String portName, Object value) {
+        NodePort p = getOutput(portName);
+        if (p != null) {
+            p.setValue(value);
+        }
+    }
+
+    // ---- Dirty propagation ----
+
+    /**
+     * Mark this node as needing re-evaluation and propagate the dirty flag
+     * to all nodes connected to this node's outputs.
+     */
+    public void markDirty() {
+        if (dirty) return; // already dirty, avoid infinite recursion
+        dirty = true;
+        for (NodePort out : outputs) {
+            // The wire list is managed by NodeGraph; here we only have the
+            // single-wire link on each connected input port. The graph's
+            // evaluate loop handles full propagation via topological order,
+            // but we still flag directly connected nodes for responsiveness.
+            // (NodeGraph.markDownstreamDirty provides the full BFS.)
+        }
+    }
+
+    /**
+     * Mark dirty unconditionally (used by NodeGraph during downstream propagation).
+     */
+    void forceDirty() {
+        this.dirty = true;
+    }
+
+    // ---- Port lookup ----
+
+    public NodePort getInput(String name) {
+        for (NodePort p : inputs) {
+            if (p.getName().equals(name)) return p;
+        }
+        return null;
+    }
+
+    public NodePort getOutput(String name) {
+        for (NodePort p : outputs) {
+            if (p.getName().equals(name)) return p;
+        }
+        return null;
+    }
+
+    // ---- Getters / Setters ----
+
+    public String getNodeId() {
+        return nodeId;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public void setCategory(String category) {
+        this.category = category;
+    }
+
+    public int getColor() {
+        return color;
+    }
+
+    public void setColor(int color) {
+        this.color = color;
+    }
+
+    public float getPosX() {
+        return posX;
+    }
+
+    public void setPosX(float posX) {
+        this.posX = posX;
+    }
+
+    public float getPosY() {
+        return posY;
+    }
+
+    public void setPosY(float posY) {
+        this.posY = posY;
+    }
+
+    public boolean isCollapsed() {
+        return collapsed;
+    }
+
+    public void setCollapsed(boolean collapsed) {
+        this.collapsed = collapsed;
+    }
+
+    public List<NodePort> getInputs() {
+        return Collections.unmodifiableList(inputs);
+    }
+
+    public List<NodePort> getOutputs() {
+        return Collections.unmodifiableList(outputs);
+    }
+
+    public boolean isDirty() {
+        return dirty;
+    }
+
+    public void setDirty(boolean dirty) {
+        this.dirty = dirty;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public long getLastEvalTimeNs() {
+        return lastEvalTimeNs;
+    }
+
+    public void setLastEvalTimeNs(long lastEvalTimeNs) {
+        this.lastEvalTimeNs = lastEvalTimeNs;
+    }
+
+    @Override
+    public String toString() {
+        return "BRNode[" + displayName + " (" + category + ") id=" + nodeId.substring(0, 8) + "]";
+    }
+}

--- a/Block Reality/api/src/main/java/com/blockreality/api/node/EvaluateScheduler.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/node/EvaluateScheduler.java
@@ -1,0 +1,72 @@
+package com.blockreality.api.node;
+
+/**
+ * Static scheduler that evaluates the active node graph each frame.
+ * Called once per tick from the render/game loop (e.g. BRRenderPipeline.onRenderLevel AFTER_LEVEL).
+ * Runs on both client and server sides.
+ */
+public final class EvaluateScheduler {
+    private EvaluateScheduler() {}
+
+    private static NodeGraph activeGraph;
+    private static boolean initialized;
+    private static long lastEvalTimeNs;
+    private static int dirtyNodesEvaluated;
+
+    /**
+     * Initialize the scheduler. Safe to call multiple times.
+     */
+    public static void init() {
+        if (initialized) return;
+        activeGraph = null;
+        lastEvalTimeNs = 0;
+        dirtyNodesEvaluated = 0;
+        initialized = true;
+    }
+
+    /**
+     * Tear down the scheduler and release the active graph reference.
+     */
+    public static void cleanup() {
+        activeGraph = null;
+        lastEvalTimeNs = 0;
+        dirtyNodesEvaluated = 0;
+        initialized = false;
+    }
+
+    public static void setActiveGraph(NodeGraph graph) {
+        activeGraph = graph;
+    }
+
+    public static NodeGraph getActiveGraph() {
+        return activeGraph;
+    }
+
+    /**
+     * Evaluate the active graph if any nodes are dirty. Intended to be
+     * called once per frame/tick from the game loop.
+     */
+    public static void tick() {
+        if (!initialized || activeGraph == null) return;
+        if (!activeGraph.hasDirtyNodes()) {
+            dirtyNodesEvaluated = 0;
+            return;
+        }
+
+        long t0 = System.nanoTime();
+        dirtyNodesEvaluated = activeGraph.evaluate();
+        lastEvalTimeNs = System.nanoTime() - t0;
+    }
+
+    public static long getLastEvalTimeNs() {
+        return lastEvalTimeNs;
+    }
+
+    public static int getDirtyNodesEvaluated() {
+        return dirtyNodesEvaluated;
+    }
+
+    public static boolean isInitialized() {
+        return initialized;
+    }
+}

--- a/Block Reality/api/src/main/java/com/blockreality/api/node/NodeGraph.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/node/NodeGraph.java
@@ -1,0 +1,308 @@
+package com.blockreality.api.node;
+
+import java.util.*;
+
+/**
+ * DAG manager that holds all nodes and wires, performs topological sorting,
+ * and evaluates dirty nodes in dependency order.
+ */
+public class NodeGraph {
+    private final String graphId;
+    private String name;
+    private final Map<String, BRNode> nodes = new LinkedHashMap<>();
+    private final List<Wire> wires = new ArrayList<>();
+    private List<BRNode> evaluationOrder = new ArrayList<>();
+    private boolean orderDirty = true;
+
+    public NodeGraph(String name) {
+        this.graphId = UUID.randomUUID().toString();
+        this.name = name;
+    }
+
+    // ---- Node management ----
+
+    public void addNode(BRNode node) {
+        nodes.put(node.getNodeId(), node);
+        orderDirty = true;
+    }
+
+    /**
+     * Remove a node and all wires connected to any of its ports.
+     */
+    public void removeNode(String nodeId) {
+        BRNode node = nodes.remove(nodeId);
+        if (node == null) return;
+
+        // Remove all wires touching this node
+        Iterator<Wire> it = wires.iterator();
+        while (it.hasNext()) {
+            Wire w = it.next();
+            if (w.getSource().getOwner() == node || w.getTarget().getOwner() == node) {
+                w.disconnect();
+                it.remove();
+            }
+        }
+        orderDirty = true;
+    }
+
+    public BRNode getNode(String nodeId) {
+        return nodes.get(nodeId);
+    }
+
+    public Collection<BRNode> getAllNodes() {
+        return Collections.unmodifiableCollection(nodes.values());
+    }
+
+    // ---- Wire management ----
+
+    /**
+     * Create a wire from an output port to an input port after validating
+     * type compatibility. If the input port is already connected, the old
+     * wire is removed first (inputs accept at most one wire).
+     *
+     * @throws IllegalArgumentException on type mismatch or wrong port direction
+     */
+    public Wire connect(NodePort source, NodePort target) {
+        // Disconnect any existing wire on the input
+        if (target.isConnected()) {
+            disconnect(target);
+        }
+
+        Wire wire = new Wire(source, target);
+        wires.add(wire);
+        target.setConnectedWire(wire);
+        orderDirty = true;
+
+        // Mark the target node (and everything downstream) dirty
+        markDownstreamDirty(target.getOwner());
+
+        return wire;
+    }
+
+    public void disconnect(Wire wire) {
+        wire.disconnect();
+        wires.remove(wire);
+        orderDirty = true;
+    }
+
+    /**
+     * Remove all wires connected to a specific port.
+     */
+    public void disconnect(NodePort port) {
+        Iterator<Wire> it = wires.iterator();
+        while (it.hasNext()) {
+            Wire w = it.next();
+            if (w.getSource() == port || w.getTarget() == port) {
+                w.disconnect();
+                it.remove();
+            }
+        }
+        orderDirty = true;
+    }
+
+    // ---- Evaluation ----
+
+    /**
+     * Rebuild topological order if needed, then evaluate every dirty node
+     * in dependency order. Returns the number of nodes evaluated.
+     */
+    public int evaluate() {
+        if (orderDirty) {
+            rebuildTopologicalOrder();
+            orderDirty = false;
+        }
+
+        int evaluated = 0;
+        for (BRNode node : evaluationOrder) {
+            if (!node.isEnabled()) continue;
+            if (!node.isDirty()) continue;
+
+            long t0 = System.nanoTime();
+            node.evaluate();
+            node.setLastEvalTimeNs(System.nanoTime() - t0);
+            node.setDirty(false);
+            evaluated++;
+        }
+        return evaluated;
+    }
+
+    /**
+     * Kahn's algorithm for topological sorting of the node DAG.
+     * <ol>
+     *   <li>Compute in-degree for each node (count incoming wires to input ports).</li>
+     *   <li>Add all zero-in-degree nodes to queue.</li>
+     *   <li>Process queue: for each node, reduce in-degree of downstream nodes.</li>
+     *   <li>Result = evaluation order.</li>
+     * </ol>
+     */
+    private void rebuildTopologicalOrder() {
+        // Compute in-degrees
+        Map<String, Integer> inDegree = new HashMap<>();
+        for (BRNode node : nodes.values()) {
+            inDegree.put(node.getNodeId(), 0);
+        }
+        // Build adjacency: source node -> set of target nodes
+        Map<String, Set<String>> adjacency = new HashMap<>();
+        for (BRNode node : nodes.values()) {
+            adjacency.put(node.getNodeId(), new HashSet<>());
+        }
+        for (Wire w : wires) {
+            String srcId = w.getSource().getOwner().getNodeId();
+            String tgtId = w.getTarget().getOwner().getNodeId();
+            if (adjacency.get(srcId).add(tgtId)) {
+                inDegree.merge(tgtId, 1, Integer::sum);
+            }
+        }
+
+        // Seed queue with zero-in-degree nodes
+        Deque<String> queue = new ArrayDeque<>();
+        for (Map.Entry<String, Integer> entry : inDegree.entrySet()) {
+            if (entry.getValue() == 0) {
+                queue.add(entry.getKey());
+            }
+        }
+
+        List<BRNode> sorted = new ArrayList<>(nodes.size());
+        while (!queue.isEmpty()) {
+            String id = queue.poll();
+            sorted.add(nodes.get(id));
+            for (String downstream : adjacency.getOrDefault(id, Collections.emptySet())) {
+                int deg = inDegree.merge(downstream, -1, Integer::sum);
+                if (deg == 0) {
+                    queue.add(downstream);
+                }
+            }
+        }
+
+        // If sorted.size() < nodes.size(), there is a cycle — include remaining
+        // nodes at the end so they are still reachable (but may evaluate in
+        // undefined order).
+        if (sorted.size() < nodes.size()) {
+            Set<String> visited = new HashSet<>();
+            for (BRNode n : sorted) visited.add(n.getNodeId());
+            for (BRNode n : nodes.values()) {
+                if (!visited.contains(n.getNodeId())) {
+                    sorted.add(n);
+                }
+            }
+        }
+
+        this.evaluationOrder = sorted;
+    }
+
+    /**
+     * BFS from a node's outputs to mark all downstream nodes dirty.
+     */
+    void markDownstreamDirty(BRNode node) {
+        Deque<BRNode> queue = new ArrayDeque<>();
+        Set<String> visited = new HashSet<>();
+        queue.add(node);
+        visited.add(node.getNodeId());
+        node.forceDirty();
+
+        while (!queue.isEmpty()) {
+            BRNode current = queue.poll();
+            for (NodePort out : current.getOutputs()) {
+                // Find wires whose source is this output
+                for (Wire w : wires) {
+                    if (w.getSource() == out) {
+                        BRNode downstream = w.getTarget().getOwner();
+                        if (visited.add(downstream.getNodeId())) {
+                            downstream.forceDirty();
+                            queue.add(downstream);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- Query ----
+
+    public int getNodeCount() {
+        return nodes.size();
+    }
+
+    public int getWireCount() {
+        return wires.size();
+    }
+
+    public List<BRNode> getNodesInCategory(String category) {
+        List<BRNode> result = new ArrayList<>();
+        for (BRNode node : nodes.values()) {
+            if (category.equals(node.getCategory())) {
+                result.add(node);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Find all nodes in the connected subgraph that contains the given node (BFS,
+     * treating wires as undirected edges).
+     */
+    public List<BRNode> findConnectedSubgraph(String nodeId) {
+        BRNode start = nodes.get(nodeId);
+        if (start == null) return Collections.emptyList();
+
+        // Build undirected adjacency
+        Map<String, Set<String>> adj = new HashMap<>();
+        for (Wire w : wires) {
+            String s = w.getSource().getOwner().getNodeId();
+            String t = w.getTarget().getOwner().getNodeId();
+            adj.computeIfAbsent(s, k -> new HashSet<>()).add(t);
+            adj.computeIfAbsent(t, k -> new HashSet<>()).add(s);
+        }
+
+        List<BRNode> result = new ArrayList<>();
+        Set<String> visited = new HashSet<>();
+        Deque<String> queue = new ArrayDeque<>();
+        queue.add(nodeId);
+        visited.add(nodeId);
+
+        while (!queue.isEmpty()) {
+            String id = queue.poll();
+            result.add(nodes.get(id));
+            for (String neighbor : adj.getOrDefault(id, Collections.emptySet())) {
+                if (visited.add(neighbor)) {
+                    queue.add(neighbor);
+                }
+            }
+        }
+        return result;
+    }
+
+    // ---- Getters / Setters ----
+
+    public String getGraphId() {
+        return graphId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<BRNode> getEvaluationOrder() {
+        if (orderDirty) {
+            rebuildTopologicalOrder();
+            orderDirty = false;
+        }
+        return Collections.unmodifiableList(evaluationOrder);
+    }
+
+    public boolean hasDirtyNodes() {
+        for (BRNode node : nodes.values()) {
+            if (node.isEnabled() && node.isDirty()) return true;
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return "NodeGraph[" + name + " nodes=" + nodes.size() + " wires=" + wires.size() + "]";
+    }
+}

--- a/Block Reality/api/src/main/java/com/blockreality/api/node/NodeGraphIO.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/node/NodeGraphIO.java
@@ -1,0 +1,420 @@
+package com.blockreality.api.node;
+
+import com.blockreality.api.node.nodes.render.EffectToggleNode;
+import com.blockreality.api.node.nodes.render.QualityPresetNode;
+import com.google.gson.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+import java.util.*;
+import java.util.function.Supplier;
+
+/**
+ * 節點圖 JSON 序列化 / 反序列化。
+ *
+ * 格式版本 1.1 — 支援節點位置、折疊狀態、端口值、連線。
+ * 內建品質預設可直接載入（Potato / Low / Medium / High / Ultra）。
+ */
+public final class NodeGraphIO {
+
+    private NodeGraphIO() {}
+
+    private static final Logger LOG = LoggerFactory.getLogger("BR-NodeIO");
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+
+    /** Node factory registry: type name → constructor */
+    private static final Map<String, Supplier<BRNode>> nodeFactories = new HashMap<>();
+
+    static {
+        // Register built-in node types
+        registerNodeType("QualityPresetNode", QualityPresetNode::new);
+        registerNodeType("EffectToggleNode_ssao", EffectToggleNode::createSSAO);
+        registerNodeType("EffectToggleNode_ssr", EffectToggleNode::createSSR);
+        registerNodeType("EffectToggleNode_taa", EffectToggleNode::createTAA);
+        registerNodeType("EffectToggleNode_bloom", EffectToggleNode::createBloom);
+        registerNodeType("EffectToggleNode_volumetric", EffectToggleNode::createVolumetric);
+        registerNodeType("EffectToggleNode_dof", EffectToggleNode::createDOF);
+        registerNodeType("EffectToggleNode_motion_blur", EffectToggleNode::createMotionBlur);
+        registerNodeType("EffectToggleNode_contact_shadow", EffectToggleNode::createContactShadow);
+        registerNodeType("EffectToggleNode_ssgi", EffectToggleNode::createSSGI);
+        registerNodeType("EffectToggleNode_vct", EffectToggleNode::createVCT);
+        registerNodeType("EffectToggleNode_sss", EffectToggleNode::createSSS);
+        registerNodeType("EffectToggleNode_anisotropic", EffectToggleNode::createAnisotropic);
+        registerNodeType("EffectToggleNode_pom", EffectToggleNode::createPOM);
+    }
+
+    /**
+     * Register a node type for deserialization.
+     *
+     * @param typeName the type identifier stored in JSON
+     * @param factory  supplier that creates a fresh instance of that node type
+     */
+    public static void registerNodeType(String typeName, Supplier<BRNode> factory) {
+        nodeFactories.put(typeName, factory);
+    }
+
+    // ═══════════════════════════════════════════════════════
+    //  序列化
+    // ═══════════════════════════════════════════════════════
+
+    /**
+     * Serialize a node graph to JSON string.
+     */
+    public static String serialize(NodeGraph graph) {
+        JsonObject root = new JsonObject();
+        root.addProperty("version", "1.1");
+        root.addProperty("name", graph.getName());
+
+        // Nodes array
+        JsonArray nodesArray = new JsonArray();
+        for (BRNode node : graph.getAllNodes()) {
+            JsonObject nodeObj = new JsonObject();
+            nodeObj.addProperty("id", node.getNodeId());
+            nodeObj.addProperty("type", resolveTypeName(node));
+            nodeObj.addProperty("displayName", node.getDisplayName());
+            nodeObj.addProperty("category", node.getCategory());
+            nodeObj.addProperty("posX", node.getPosX());
+            nodeObj.addProperty("posY", node.getPosY());
+            nodeObj.addProperty("enabled", node.isEnabled());
+            nodeObj.addProperty("collapsed", node.isCollapsed());
+
+            // Save input port values
+            JsonObject portsObj = new JsonObject();
+            for (NodePort port : node.getInputs()) {
+                if (port.getValue() != null) {
+                    portsObj.add(port.getName(), serializeValue(port));
+                }
+            }
+            nodeObj.add("inputs", portsObj);
+            nodesArray.add(nodeObj);
+        }
+        root.add("nodes", nodesArray);
+
+        // Wires array
+        JsonArray wiresArray = new JsonArray();
+        for (BRNode node : graph.getAllNodes()) {
+            for (NodePort input : node.getInputs()) {
+                NodePort source = input.getConnectedSource();
+                if (source != null) {
+                    JsonObject wire = new JsonObject();
+                    wire.addProperty("fromNode", source.getOwner().getNodeId());
+                    wire.addProperty("fromPort", source.getName());
+                    wire.addProperty("toNode", node.getNodeId());
+                    wire.addProperty("toPort", input.getName());
+                    wiresArray.add(wire);
+                }
+            }
+        }
+        root.add("wires", wiresArray);
+
+        return GSON.toJson(root);
+    }
+
+    // ═══════════════════════════════════════════════════════
+    //  反序列化
+    // ═══════════════════════════════════════════════════════
+
+    /**
+     * Deserialize a node graph from JSON string.
+     */
+    public static NodeGraph deserialize(String json) {
+        JsonObject root = GSON.fromJson(json, JsonObject.class);
+        String version = root.has("version") ? root.get("version").getAsString() : "1.0";
+        String name = root.has("name") ? root.get("name").getAsString() : "Untitled";
+
+        NodeGraph graph = new NodeGraph(name);
+
+        // Map from serialized ID → deserialized node for wire reconnection
+        Map<String, BRNode> nodeById = new HashMap<>();
+
+        // Deserialize nodes
+        JsonArray nodesArray = root.getAsJsonArray("nodes");
+        if (nodesArray != null) {
+            for (JsonElement elem : nodesArray) {
+                JsonObject nodeObj = elem.getAsJsonObject();
+                String typeName = nodeObj.get("type").getAsString();
+                String id = nodeObj.get("id").getAsString();
+
+                Supplier<BRNode> factory = nodeFactories.get(typeName);
+                if (factory == null) {
+                    LOG.warn("[NodeIO] 未知節點類型 '{}' (id={}), 跳過", typeName, id);
+                    continue;
+                }
+
+                BRNode node = factory.get();
+                node.setNodeId(id);
+
+                // Restore position
+                if (nodeObj.has("posX")) node.setPosX(nodeObj.get("posX").getAsFloat());
+                if (nodeObj.has("posY")) node.setPosY(nodeObj.get("posY").getAsFloat());
+
+                // Restore state
+                if (nodeObj.has("enabled")) node.setEnabled(nodeObj.get("enabled").getAsBoolean());
+                if (nodeObj.has("collapsed")) node.setCollapsed(nodeObj.get("collapsed").getAsBoolean());
+
+                // Restore input port values
+                if (nodeObj.has("inputs")) {
+                    JsonObject portsObj = nodeObj.getAsJsonObject("inputs");
+                    for (Map.Entry<String, JsonElement> entry : portsObj.entrySet()) {
+                        NodePort port = node.getInput(entry.getKey());
+                        if (port != null) {
+                            Object value = deserializeValue(entry.getValue(), port.getType());
+                            if (value != null) {
+                                port.setValue(value);
+                            }
+                        }
+                    }
+                }
+
+                graph.addNode(node);
+                nodeById.put(id, node);
+            }
+        }
+
+        // Deserialize wires
+        JsonArray wiresArray = root.getAsJsonArray("wires");
+        if (wiresArray != null) {
+            for (JsonElement elem : wiresArray) {
+                JsonObject wire = elem.getAsJsonObject();
+                String fromNodeId = wire.get("fromNode").getAsString();
+                String fromPortName = wire.get("fromPort").getAsString();
+                String toNodeId = wire.get("toNode").getAsString();
+                String toPortName = wire.get("toPort").getAsString();
+
+                BRNode fromNode = nodeById.get(fromNodeId);
+                BRNode toNode = nodeById.get(toNodeId);
+
+                if (fromNode == null || toNode == null) {
+                    LOG.warn("[NodeIO] 連線參照不存在的節點: {} → {}", fromNodeId, toNodeId);
+                    continue;
+                }
+
+                NodePort fromPort = fromNode.getOutput(fromPortName);
+                NodePort toPort = toNode.getInput(toPortName);
+
+                if (fromPort == null || toPort == null) {
+                    LOG.warn("[NodeIO] 連線參照不存在的端口: {}.{} → {}.{}",
+                        fromNodeId, fromPortName, toNodeId, toPortName);
+                    continue;
+                }
+
+                graph.connect(fromPort, toPort);
+            }
+        }
+
+        LOG.info("[NodeIO] 反序列化完成 — '{}' (v{}) {} 節點, {} 連線",
+            name, version,
+            nodesArray != null ? nodesArray.size() : 0,
+            wiresArray != null ? wiresArray.size() : 0);
+
+        return graph;
+    }
+
+    // ═══════════════════════════════════════════════════════
+    //  檔案 I/O
+    // ═══════════════════════════════════════════════════════
+
+    /**
+     * Save a node graph to a JSON file.
+     */
+    public static void saveToFile(NodeGraph graph, Path path) throws IOException {
+        String json = serialize(graph);
+        Files.createDirectories(path.getParent());
+        Files.writeString(path, json, StandardCharsets.UTF_8);
+        LOG.info("[NodeIO] 節點圖儲存至: {}", path);
+    }
+
+    /**
+     * Load a node graph from a JSON file.
+     */
+    public static NodeGraph loadFromFile(Path path) throws IOException {
+        if (!Files.exists(path)) {
+            throw new IOException("節點圖檔案不存在: " + path);
+        }
+        String json = Files.readString(path, StandardCharsets.UTF_8);
+        LOG.info("[NodeIO] 從檔案載入節點圖: {}", path);
+        return deserialize(json);
+    }
+
+    /**
+     * Load a preset from embedded resources.
+     *
+     * @param presetName one of "potato", "low", "medium", "high", "ultra"
+     * @return the preset node graph, or a default High preset if not found
+     */
+    public static NodeGraph loadPreset(String presetName) {
+        return switch (presetName.toLowerCase()) {
+            case "potato" -> createPotatoPreset();
+            case "low" -> createLowPreset();
+            case "medium" -> createMediumPreset();
+            case "high" -> createHighPreset();
+            case "ultra" -> createUltraPreset();
+            default -> {
+                LOG.warn("[NodeIO] 未知預設名稱 '{}', 使用 High", presetName);
+                yield createHighPreset();
+            }
+        };
+    }
+
+    // ═══════════════════════════════════════════════════════
+    //  內建品質預設
+    // ═══════════════════════════════════════════════════════
+
+    /** Create a Potato quality preset — minimal effects for lowest-end hardware. */
+    public static NodeGraph createPotatoPreset() {
+        NodeGraph g = new NodeGraph("Potato Quality");
+        QualityPresetNode qp = new QualityPresetNode();
+        qp.getInput("preset").setValue(0);
+        g.addNode(qp);
+        qp.evaluate();
+        return g;
+    }
+
+    /** Create a Low quality preset — basic effects for low-end hardware. */
+    public static NodeGraph createLowPreset() {
+        NodeGraph g = new NodeGraph("Low Quality");
+        QualityPresetNode qp = new QualityPresetNode();
+        qp.getInput("preset").setValue(1);
+        g.addNode(qp);
+        qp.evaluate();
+        return g;
+    }
+
+    /** Create a Medium quality preset — balanced quality and performance. */
+    public static NodeGraph createMediumPreset() {
+        NodeGraph g = new NodeGraph("Medium Quality");
+        QualityPresetNode qp = new QualityPresetNode();
+        qp.getInput("preset").setValue(2);
+        g.addNode(qp);
+        qp.evaluate();
+        return g;
+    }
+
+    /** Create a High quality preset — high quality, recommended for most users. */
+    public static NodeGraph createHighPreset() {
+        NodeGraph g = new NodeGraph("High Quality");
+        QualityPresetNode qp = new QualityPresetNode();
+        qp.getInput("preset").setValue(3);
+        g.addNode(qp);
+        qp.evaluate();
+        return g;
+    }
+
+    /** Create an Ultra quality preset — maximum quality, all effects enabled. */
+    public static NodeGraph createUltraPreset() {
+        NodeGraph g = new NodeGraph("Ultra Quality");
+        QualityPresetNode qp = new QualityPresetNode();
+        qp.getInput("preset").setValue(4);
+        g.addNode(qp);
+        qp.evaluate();
+        return g;
+    }
+
+    // ═══════════════════════════════════════════════════════
+    //  值序列化 / 反序列化
+    // ═══════════════════════════════════════════════════════
+
+    private static JsonElement serializeValue(NodePort port) {
+        Object value = port.getValue();
+        if (value == null) return JsonNull.INSTANCE;
+
+        return switch (port.getType()) {
+            case FLOAT -> new JsonPrimitive(((Number) value).floatValue());
+            case INT, COLOR, TEXTURE -> new JsonPrimitive(((Number) value).intValue());
+            case BOOL -> new JsonPrimitive((Boolean) value);
+            case VEC2 -> {
+                float[] v = (float[]) value;
+                JsonArray arr = new JsonArray();
+                arr.add(v.length > 0 ? v[0] : 0f);
+                arr.add(v.length > 1 ? v[1] : 0f);
+                yield arr;
+            }
+            case VEC3 -> {
+                float[] v = (float[]) value;
+                JsonArray arr = new JsonArray();
+                arr.add(v.length > 0 ? v[0] : 0f);
+                arr.add(v.length > 1 ? v[1] : 0f);
+                arr.add(v.length > 2 ? v[2] : 0f);
+                yield arr;
+            }
+            case VEC4 -> {
+                float[] v = (float[]) value;
+                JsonArray arr = new JsonArray();
+                arr.add(v.length > 0 ? v[0] : 0f);
+                arr.add(v.length > 1 ? v[1] : 0f);
+                arr.add(v.length > 2 ? v[2] : 0f);
+                arr.add(v.length > 3 ? v[3] : 0f);
+                yield arr;
+            }
+            case CURVE -> {
+                float[] v = (float[]) value;
+                JsonArray arr = new JsonArray();
+                for (float f : v) arr.add(f);
+                yield arr;
+            }
+            case ENUM -> new JsonPrimitive(value.toString());
+            default -> new JsonPrimitive(value.toString());
+        };
+    }
+
+    private static Object deserializeValue(JsonElement elem, PortType type) {
+        if (elem == null || elem.isJsonNull()) return null;
+
+        try {
+            return switch (type) {
+                case FLOAT -> elem.getAsFloat();
+                case INT, COLOR, TEXTURE -> elem.getAsInt();
+                case BOOL -> elem.getAsBoolean();
+                case VEC2 -> {
+                    JsonArray arr = elem.getAsJsonArray();
+                    yield new float[]{
+                        arr.size() > 0 ? arr.get(0).getAsFloat() : 0f,
+                        arr.size() > 1 ? arr.get(1).getAsFloat() : 0f
+                    };
+                }
+                case VEC3 -> {
+                    JsonArray arr = elem.getAsJsonArray();
+                    yield new float[]{
+                        arr.size() > 0 ? arr.get(0).getAsFloat() : 0f,
+                        arr.size() > 1 ? arr.get(1).getAsFloat() : 0f,
+                        arr.size() > 2 ? arr.get(2).getAsFloat() : 0f
+                    };
+                }
+                case VEC4 -> {
+                    JsonArray arr = elem.getAsJsonArray();
+                    yield new float[]{
+                        arr.size() > 0 ? arr.get(0).getAsFloat() : 0f,
+                        arr.size() > 1 ? arr.get(1).getAsFloat() : 0f,
+                        arr.size() > 2 ? arr.get(2).getAsFloat() : 0f,
+                        arr.size() > 3 ? arr.get(3).getAsFloat() : 0f
+                    };
+                }
+                case CURVE -> {
+                    JsonArray arr = elem.getAsJsonArray();
+                    float[] vals = new float[arr.size()];
+                    for (int i = 0; i < arr.size(); i++) vals[i] = arr.get(i).getAsFloat();
+                    yield vals;
+                }
+                case ENUM -> elem.getAsString();
+                default -> elem.getAsString();
+            };
+        } catch (Exception e) {
+            LOG.warn("[NodeIO] 值反序列化失敗 (type={}, elem={}): {}", type, elem, e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Resolve the serialization type name for a node.
+     * EffectToggleNode instances include their effect name suffix.
+     */
+    private static String resolveTypeName(BRNode node) {
+        if (node instanceof EffectToggleNode effectNode) {
+            return "EffectToggleNode_" + effectNode.getEffectName();
+        }
+        return node.getClass().getSimpleName();
+    }
+}

--- a/Block Reality/api/src/main/java/com/blockreality/api/node/NodePort.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/node/NodePort.java
@@ -1,0 +1,124 @@
+package com.blockreality.api.node;
+
+/**
+ * A port on a node (input or output). Input ports accept at most one incoming wire;
+ * output ports can fan out to many wires (managed by NodeGraph).
+ */
+public class NodePort {
+    private final String name;
+    private final PortType type;
+    private final boolean isInput;
+    private final BRNode owner;
+    private Object value;
+    private Object defaultValue;
+    private Wire connectedWire;   // for input ports (single wire); outputs track wires via NodeGraph
+    private float min;
+    private float max;
+    private boolean hasRange;
+
+    public NodePort(String name, PortType type, boolean isInput, BRNode owner, Object defaultValue) {
+        this.name = name;
+        this.type = type;
+        this.isInput = isInput;
+        this.owner = owner;
+        this.defaultValue = defaultValue;
+        this.value = defaultValue;
+    }
+
+    // ---- Value access ----
+
+    /**
+     * Set the port value directly. Marks the owning node dirty so it will be
+     * re-evaluated on the next graph tick.
+     */
+    public void setValue(Object value) {
+        this.value = value;
+        if (owner != null) {
+            owner.markDirty();
+        }
+    }
+
+    /**
+     * Returns the effective value of this port. For a connected input port the
+     * value is pulled from the source end of the wire (with auto-conversion);
+     * otherwise the port's own value is returned.
+     */
+    public Object getValue() {
+        if (isInput && connectedWire != null) {
+            return connectedWire.getSourceValue();
+        }
+        return value;
+    }
+
+    public Object getDefaultValue() {
+        return defaultValue;
+    }
+
+    public void setDefaultValue(Object defaultValue) {
+        this.defaultValue = defaultValue;
+    }
+
+    // ---- Connection ----
+
+    public boolean isConnected() {
+        return connectedWire != null;
+    }
+
+    public void setConnectedWire(Wire wire) {
+        this.connectedWire = wire;
+    }
+
+    public Wire getConnectedWire() {
+        return connectedWire;
+    }
+
+    /**
+     * Disconnect the wire attached to this port (input side).
+     */
+    public void disconnect() {
+        this.connectedWire = null;
+    }
+
+    // ---- Range (for FLOAT / INT slider UI) ----
+
+    public void setRange(float min, float max) {
+        this.min = min;
+        this.max = max;
+        this.hasRange = true;
+    }
+
+    public float getMin() {
+        return min;
+    }
+
+    public float getMax() {
+        return max;
+    }
+
+    public boolean hasRange() {
+        return hasRange;
+    }
+
+    // ---- Identity ----
+
+    public String getName() {
+        return name;
+    }
+
+    public PortType getType() {
+        return type;
+    }
+
+    public boolean isInput() {
+        return isInput;
+    }
+
+    public BRNode getOwner() {
+        return owner;
+    }
+
+    @Override
+    public String toString() {
+        return (isInput ? "IN" : "OUT") + "[" + name + ":" + type.id + "]";
+    }
+}

--- a/Block Reality/api/src/main/java/com/blockreality/api/node/PortType.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/node/PortType.java
@@ -1,0 +1,44 @@
+package com.blockreality.api.node;
+
+public enum PortType {
+    FLOAT(float.class, "FLOAT", 0xCCCCCC),
+    INT(int.class, "INT", 0x88BBFF),
+    BOOL(boolean.class, "BOOL", 0xFFCC00),
+    VEC2(float[].class, "VEC2", 0xCC88FF),
+    VEC3(float[].class, "VEC3", 0x00CCCC),
+    VEC4(float[].class, "VEC4", 0xFF88CC),
+    COLOR(int.class, "COLOR", 0xFFFFFF),
+    MATERIAL(Object.class, "MATERIAL", 0x44CC44),
+    BLOCK(Object.class, "BLOCK", 0x00CC88),
+    SHAPE(Object.class, "SHAPE", 0xAA7744),
+    TEXTURE(int.class, "TEXTURE", 0xFF6644),
+    ENUM(Object.class, "ENUM", 0xFFFFFF),
+    CURVE(float[].class, "CURVE", 0x8844CC),
+    STRUCT(Object.class, "STRUCT", 0xAAAAAA);
+
+    public final Class<?> javaType;
+    public final String id;
+    public final int wireColor;
+
+    PortType(Class<?> t, String id, int c) {
+        this.javaType = t;
+        this.id = id;
+        this.wireColor = c;
+    }
+
+    /**
+     * Check whether this port type can connect to the given target type.
+     * Allows same-type connections and a set of auto-conversions.
+     */
+    public boolean canConnectTo(PortType target) {
+        if (this == target) return true;
+        // Auto-conversions
+        if (this == FLOAT && target == INT) return true;
+        if (this == INT && target == FLOAT) return true;
+        if (this == BOOL && (target == INT || target == FLOAT)) return true;
+        if (this == VEC3 && target == COLOR) return true;
+        if (this == COLOR && target == VEC3) return true;
+        if (this == BLOCK && target == MATERIAL) return true;
+        return false;
+    }
+}

--- a/Block Reality/api/src/main/java/com/blockreality/api/node/Wire.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/node/Wire.java
@@ -1,0 +1,149 @@
+package com.blockreality.api.node;
+
+import java.util.UUID;
+
+/**
+ * A directed connection from an output port (source) to an input port (target).
+ * Handles automatic type conversion when the two port types differ.
+ */
+public class Wire {
+    private final String wireId;
+    private final NodePort source;  // output port
+    private final NodePort target;  // input port
+
+    /**
+     * Create a wire between {@code source} (output) and {@code target} (input).
+     *
+     * @throws IllegalArgumentException if the types are incompatible, if source
+     *         is not an output port, or if target is not an input port.
+     */
+    public Wire(NodePort source, NodePort target) {
+        if (source.isInput()) {
+            throw new IllegalArgumentException("Source port must be an output port");
+        }
+        if (!target.isInput()) {
+            throw new IllegalArgumentException("Target port must be an input port");
+        }
+        if (!source.getType().canConnectTo(target.getType())) {
+            throw new IllegalArgumentException(
+                    "Incompatible types: " + source.getType().id + " -> " + target.getType().id);
+        }
+        this.wireId = UUID.randomUUID().toString();
+        this.source = source;
+        this.target = target;
+    }
+
+    // ---- Value with auto-conversion ----
+
+    /**
+     * Pull the source port's value and convert it to the target port's type
+     * when the two differ.
+     */
+    public Object getSourceValue() {
+        Object val = source.getValue();
+        PortType srcType = source.getType();
+        PortType tgtType = target.getType();
+
+        if (srcType == tgtType || val == null) {
+            return val;
+        }
+
+        // FLOAT -> INT
+        if (srcType == PortType.FLOAT && tgtType == PortType.INT) {
+            return Math.round(toFloat(val));
+        }
+        // INT -> FLOAT
+        if (srcType == PortType.INT && tgtType == PortType.FLOAT) {
+            return (float) toInt(val);
+        }
+        // BOOL -> INT
+        if (srcType == PortType.BOOL && tgtType == PortType.INT) {
+            return toBool(val) ? 1 : 0;
+        }
+        // BOOL -> FLOAT
+        if (srcType == PortType.BOOL && tgtType == PortType.FLOAT) {
+            return toBool(val) ? 1.0f : 0.0f;
+        }
+        // VEC3 -> COLOR  (pack RGB float[3] 0..1 into 0xRRGGBB int)
+        if (srcType == PortType.VEC3 && tgtType == PortType.COLOR) {
+            float[] v = (float[]) val;
+            int r = clamp8(Math.round(v[0] * 255));
+            int g = clamp8(Math.round(v[1] * 255));
+            int b = clamp8(Math.round(v[2] * 255));
+            return (r << 16) | (g << 8) | b;
+        }
+        // COLOR -> VEC3  (unpack 0xRRGGBB int into float[3] 0..1)
+        if (srcType == PortType.COLOR && tgtType == PortType.VEC3) {
+            int c = toInt(val);
+            return new float[]{
+                    ((c >> 16) & 0xFF) / 255.0f,
+                    ((c >> 8) & 0xFF) / 255.0f,
+                    (c & 0xFF) / 255.0f
+            };
+        }
+        // BLOCK -> MATERIAL  (pass-through; the object carries material data)
+        if (srcType == PortType.BLOCK && tgtType == PortType.MATERIAL) {
+            return val;
+        }
+
+        // Fallback — no conversion available
+        return val;
+    }
+
+    // ---- Validation ----
+
+    /**
+     * Returns true if the source and target types are still compatible.
+     */
+    public boolean isValid() {
+        return source.getType().canConnectTo(target.getType());
+    }
+
+    /**
+     * Disconnect this wire from both its source and target ports.
+     */
+    public void disconnect() {
+        target.disconnect();
+    }
+
+    // ---- Getters ----
+
+    public String getWireId() {
+        return wireId;
+    }
+
+    public NodePort getSource() {
+        return source;
+    }
+
+    public NodePort getTarget() {
+        return target;
+    }
+
+    // ---- Helpers ----
+
+    private static float toFloat(Object v) {
+        if (v instanceof Number) return ((Number) v).floatValue();
+        return 0.0f;
+    }
+
+    private static int toInt(Object v) {
+        if (v instanceof Number) return ((Number) v).intValue();
+        return 0;
+    }
+
+    private static boolean toBool(Object v) {
+        if (v instanceof Boolean) return (Boolean) v;
+        if (v instanceof Number) return ((Number) v).intValue() != 0;
+        return false;
+    }
+
+    private static int clamp8(int v) {
+        return Math.max(0, Math.min(255, v));
+    }
+
+    @Override
+    public String toString() {
+        return "Wire[" + wireId.substring(0, 8) + " " + source + " -> " + target + "]";
+    }
+}

--- a/Block Reality/api/src/main/java/com/blockreality/api/node/binder/RenderConfigBinder.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/node/binder/RenderConfigBinder.java
@@ -1,0 +1,251 @@
+package com.blockreality.api.node.binder;
+
+import com.blockreality.api.client.render.BRRenderSettings;
+import com.blockreality.api.node.BRNode;
+import com.blockreality.api.node.NodeGraph;
+import com.blockreality.api.node.NodePort;
+import com.blockreality.api.node.nodes.render.EffectToggleNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Render Config Binder — 節點圖輸出 → BRRenderSettings 映射。
+ *
+ * 每次節點圖評估後，此 binder 讀取渲染節點的輸出端口值，
+ * 並推送到 BRRenderSettings 對應的運行時設定。
+ *
+ * 映射規則：
+ *   QualityPreset.ssaoEnabled (BOOL) → BRRenderSettings.setEffect("ssao", value)
+ *   SSAO_GTAO.kernelSize (INT)       → BRRenderSettings.setSSAOSamples(value)
+ *   ShadowConfig.resolution (INT)     → BRRenderSettings.setShadowResolution(value)
+ *   TierSelector.tier (ENUM)          → BRRenderTier.setTier(value)
+ */
+public final class RenderConfigBinder {
+
+    private RenderConfigBinder() {}
+
+    private static final Logger LOG = LoggerFactory.getLogger("BR-NodeBinder");
+
+    /** nodeType → effect name mapping (e.g. "EffectToggleNode_ssao" → "ssao") */
+    private static final Map<String, String> nodeEffectMap = new ConcurrentHashMap<>();
+
+    private static boolean initialized = false;
+
+    /**
+     * 初始化 binder — 註冊已知節點類型到效果名稱的映射。
+     */
+    public static void init() {
+        if (initialized) return;
+
+        // Register default effect mappings
+        registerMapping("ssao", "ssao");
+        registerMapping("ssr", "ssr");
+        registerMapping("ssgi", "ssgi");
+        registerMapping("taa", "taa");
+        registerMapping("bloom", "bloom");
+        registerMapping("dof", "dof");
+        registerMapping("volumetric", "volumetric");
+        registerMapping("contact_shadow", "contact_shadow");
+        registerMapping("motion_blur", "motion_blur");
+        registerMapping("cloud", "cloud");
+        registerMapping("weather", "weather");
+        registerMapping("atmosphere", "atmosphere");
+        registerMapping("water", "water");
+        registerMapping("fog", "fog");
+        registerMapping("sss", "sss");
+        registerMapping("anisotropic", "anisotropic");
+        registerMapping("pom", "pom");
+        registerMapping("vct", "vct");
+        registerMapping("rt_shadow", "rt_shadow");
+
+        initialized = true;
+        LOG.info("[NodeBinder] 渲染設定綁定器初始化完成 — {} 組映射", nodeEffectMap.size());
+    }
+
+    /**
+     * 清理 binder 狀態。
+     */
+    public static void cleanup() {
+        nodeEffectMap.clear();
+        initialized = false;
+        LOG.info("[NodeBinder] 渲染設定綁定器已清理");
+    }
+
+    /**
+     * 在節點圖評估後呼叫。掃描所有渲染類節點，推送輸出值到 BRRenderSettings。
+     */
+    public static void pushToSettings(NodeGraph graph) {
+        if (!initialized) {
+            LOG.warn("[NodeBinder] pushToSettings 呼叫但 binder 尚未初始化");
+            return;
+        }
+
+        for (BRNode node : graph.getAllNodes()) {
+            if (!"render".equals(node.getCategory())) continue;
+            if (!node.isEnabled()) continue;
+
+            // Handle EffectToggleNode instances — push enabled state and parameters
+            if (node instanceof EffectToggleNode effectNode) {
+                String effectName = effectNode.getEffectName();
+                pushEffectToggleOutputs(effectNode, effectName);
+                continue;
+            }
+
+            // Handle generic render nodes with standard output port names
+            pushGenericRenderOutputs(node);
+        }
+    }
+
+    /**
+     * Push EffectToggleNode outputs to BRRenderSettings.
+     */
+    private static void pushEffectToggleOutputs(EffectToggleNode node, String effectName) {
+        // "enabled" output → effect toggle
+        NodePort enabledPort = node.getOutput("enabled");
+        if (enabledPort != null && enabledPort.getValue() != null) {
+            boolean enabled = (boolean) enabledPort.getValue();
+            BRRenderSettings.setEffect(effectName, enabled);
+        }
+
+        // "samples" output → SSAO samples (if present)
+        NodePort samplesPort = node.getOutput("samples");
+        if (samplesPort != null && samplesPort.getValue() != null) {
+            int samples = ((Number) samplesPort.getValue()).intValue();
+            if ("ssao".equals(effectName)) {
+                BRRenderSettings.setSSAOSamples(samples);
+            }
+        }
+
+        // "resolution" output → shadow resolution (if present)
+        NodePort resPort = node.getOutput("resolution");
+        if (resPort != null && resPort.getValue() != null) {
+            int resolution = ((Number) resPort.getValue()).intValue();
+            BRRenderSettings.setShadowResolution(resolution);
+        }
+
+        // "intensity" output → could be used for per-effect intensity tuning
+        // Currently BRRenderSettings only supports on/off; reserved for future use
+    }
+
+    /**
+     * Push generic render node outputs (shadowRes, ssaoSamples, etc.) to BRRenderSettings.
+     */
+    private static void pushGenericRenderOutputs(BRNode node) {
+        // "shadowRes" output → shadow resolution
+        NodePort shadowResPort = node.getOutput("shadowRes");
+        if (shadowResPort != null && shadowResPort.getValue() != null) {
+            int res = ((Number) shadowResPort.getValue()).intValue();
+            BRRenderSettings.setShadowResolution(res);
+        }
+
+        // "ssaoSamples" output → SSAO samples
+        NodePort ssaoSamplesPort = node.getOutput("ssaoSamples");
+        if (ssaoSamplesPort != null && ssaoSamplesPort.getValue() != null) {
+            int samples = ((Number) ssaoSamplesPort.getValue()).intValue();
+            BRRenderSettings.setSSAOSamples(samples);
+        }
+
+        // Boolean effect outputs: map output port name to effect name
+        String[] boolEffectOutputs = {
+            "ssaoEnabled", "ssrEnabled", "ssgiEnabled", "taaEnabled",
+            "bloomEnabled", "dofEnabled", "volumetricEnabled",
+            "contactShadowEnabled", "motionBlurEnabled",
+            "cloudEnabled", "weatherEnabled", "waterEnabled",
+            "fogEnabled", "atmosphereEnabled",
+            "sssEnabled", "anisotropicEnabled", "pomEnabled",
+            "vctEnabled", "rtShadowEnabled"
+        };
+
+        for (String outputName : boolEffectOutputs) {
+            NodePort port = node.getOutput(outputName);
+            if (port != null && port.getValue() != null) {
+                boolean value = (boolean) port.getValue();
+                String effectName = outputNameToEffectName(outputName);
+                BRRenderSettings.setEffect(effectName, value);
+            }
+        }
+    }
+
+    /**
+     * Convert output port name (e.g. "ssaoEnabled") to BRRenderSettings effect name (e.g. "ssao").
+     */
+    private static String outputNameToEffectName(String outputName) {
+        // Strip "Enabled" suffix and convert camelCase to snake_case
+        String base = outputName.replace("Enabled", "");
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < base.length(); i++) {
+            char c = base.charAt(i);
+            if (Character.isUpperCase(c) && i > 0) {
+                sb.append('_');
+            }
+            sb.append(Character.toLowerCase(c));
+        }
+        return sb.toString();
+    }
+
+    /**
+     * 反向：從 BRRenderSettings 拉取值填入節點輸入。
+     * 初始化節點圖時呼叫，確保節點反映當前設定。
+     */
+    public static void pullFromSettings(NodeGraph graph) {
+        if (!initialized) {
+            LOG.warn("[NodeBinder] pullFromSettings 呼叫但 binder 尚未初始化");
+            return;
+        }
+
+        for (BRNode node : graph.getAllNodes()) {
+            if (!"render".equals(node.getCategory())) continue;
+
+            // Handle EffectToggleNode instances — pull enabled state
+            if (node instanceof EffectToggleNode effectNode) {
+                String effectName = effectNode.getEffectName();
+                boolean enabled = BRRenderSettings.isEffectEnabled(effectName);
+                NodePort enabledInput = node.getInput("enabled");
+                if (enabledInput != null) {
+                    enabledInput.setValue(enabled);
+                }
+                continue;
+            }
+
+            // Handle QualityPresetNode — pull shadow resolution into preset detection
+            NodePort presetInput = node.getInput("preset");
+            if (presetInput != null) {
+                // Detect current preset from BRRenderSettings state
+                int detectedPreset = detectCurrentPreset();
+                presetInput.setValue(detectedPreset);
+            }
+        }
+    }
+
+    /**
+     * Detect which quality preset best matches the current BRRenderSettings state.
+     *
+     * @return preset index: 0=Potato, 1=Low, 2=Medium, 3=High, 4=Ultra, 5=Custom
+     */
+    private static int detectCurrentPreset() {
+        int shadowRes = BRRenderSettings.getShadowResolution();
+        boolean ssao = BRRenderSettings.isSSAOEnabled();
+        boolean ssr = BRRenderSettings.isSSREnabled();
+        boolean volumetric = BRRenderSettings.isVolumetricEnabled();
+
+        if (shadowRes >= 4096 && ssao && ssr && volumetric) return 4; // Ultra
+        if (shadowRes >= 2048 && ssao && ssr && volumetric) return 3; // High
+        if (shadowRes >= 2048 && ssao && !ssr) return 2;              // Medium
+        if (shadowRes >= 1024 && ssao && !ssr) return 1;              // Low
+        if (shadowRes <= 512 && !ssao) return 0;                       // Potato
+        return 5; // Custom
+    }
+
+    /**
+     * 註冊節點類型到效果名稱的映射。
+     *
+     * @param nodeType   the node type identifier (e.g. "ssao", "ssr")
+     * @param effectName the BRRenderSettings effect name (e.g. "ssao", "ssr")
+     */
+    public static void registerMapping(String nodeType, String effectName) {
+        nodeEffectMap.put(nodeType, effectName);
+    }
+}

--- a/Block Reality/api/src/main/java/com/blockreality/api/node/nodes/render/EffectToggleNode.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/node/nodes/render/EffectToggleNode.java
@@ -1,0 +1,195 @@
+package com.blockreality.api.node.nodes.render;
+
+import com.blockreality.api.node.BRNode;
+import com.blockreality.api.node.NodePort;
+import com.blockreality.api.node.PortType;
+
+/**
+ * 通用效果切換節點 — 對應 A3 的每個後處理效果。
+ *
+ * 每個實例代表一個特定效果（SSAO、SSR、TAA、Bloom 等）。
+ * 提供 enabled 開關 + 效果特定參數輸入 + 輸出。
+ *
+ * 使用靜態工廠方法建立特定效果的節點實例，每個工廠方法
+ * 自動新增該效果專屬的參數端口與範圍限制。
+ */
+public class EffectToggleNode extends BRNode {
+
+    private final String effectName; // "ssao", "ssr", "taa" etc.
+
+    public EffectToggleNode(String effectName, String displayName) {
+        super(displayName, "render", 0x2196F3);
+        this.effectName = effectName;
+
+        // Common input
+        addInput("enabled", PortType.BOOL, true);
+
+        // Common output
+        addOutput("enabled", PortType.BOOL);
+        addOutput("effectName", PortType.ENUM);
+    }
+
+    // ═══════════════════════════════════════════════════════
+    //  靜態工廠方法 — 各效果專屬配置
+    // ═══════════════════════════════════════════════════════
+
+    /** SSAO 環境遮蔽 — Screen-Space Ambient Occlusion (GTAO variant) */
+    public static EffectToggleNode createSSAO() {
+        EffectToggleNode n = new EffectToggleNode("ssao", "SSAO 環境遮蔽");
+        n.addInput("kernelSize", PortType.INT, 32).setRange(4, 128);
+        n.addInput("radius", PortType.FLOAT, 0.5f).setRange(0.1f, 2.0f);
+        n.addInput("intensity", PortType.FLOAT, 1.0f).setRange(0.0f, 3.0f);
+        n.addOutput("samples", PortType.INT);
+        return n;
+    }
+
+    /** SSR 螢幕空間反射 — Screen-Space Reflections */
+    public static EffectToggleNode createSSR() {
+        EffectToggleNode n = new EffectToggleNode("ssr", "SSR 螢幕空間反射");
+        n.addInput("maxDistance", PortType.FLOAT, 50.0f).setRange(5.0f, 200.0f);
+        n.addInput("raySteps", PortType.INT, 64).setRange(16, 256);
+        n.addInput("thickness", PortType.FLOAT, 0.1f).setRange(0.01f, 1.0f);
+        return n;
+    }
+
+    /** TAA 時間抗鋸齒 — Temporal Anti-Aliasing */
+    public static EffectToggleNode createTAA() {
+        EffectToggleNode n = new EffectToggleNode("taa", "TAA 時間抗鋸齒");
+        n.addInput("jitterScale", PortType.FLOAT, 1.0f).setRange(0.0f, 2.0f);
+        n.addInput("feedbackMin", PortType.FLOAT, 0.88f).setRange(0.5f, 0.99f);
+        n.addInput("feedbackMax", PortType.FLOAT, 0.97f).setRange(0.5f, 0.99f);
+        n.addInput("sharpen", PortType.FLOAT, 0.1f).setRange(0.0f, 1.0f);
+        return n;
+    }
+
+    /** Bloom 泛光 — HDR Bloom */
+    public static EffectToggleNode createBloom() {
+        EffectToggleNode n = new EffectToggleNode("bloom", "Bloom 泛光");
+        n.addInput("threshold", PortType.FLOAT, 1.0f).setRange(0.0f, 5.0f);
+        n.addInput("intensity", PortType.FLOAT, 0.5f).setRange(0.0f, 3.0f);
+        n.addInput("radius", PortType.FLOAT, 4.0f).setRange(1.0f, 16.0f);
+        n.addInput("passes", PortType.INT, 6).setRange(1, 12);
+        return n;
+    }
+
+    /** Volumetric 體積光 — Volumetric Lighting / God Rays */
+    public static EffectToggleNode createVolumetric() {
+        EffectToggleNode n = new EffectToggleNode("volumetric", "Volumetric 體積光");
+        n.addInput("samples", PortType.INT, 64).setRange(16, 256);
+        n.addInput("density", PortType.FLOAT, 0.02f).setRange(0.001f, 0.1f);
+        n.addInput("scattering", PortType.FLOAT, 0.7f).setRange(0.0f, 1.0f);
+        n.addInput("maxDistance", PortType.FLOAT, 128.0f).setRange(16.0f, 512.0f);
+        return n;
+    }
+
+    /** DOF 景深 — Depth of Field */
+    public static EffectToggleNode createDOF() {
+        EffectToggleNode n = new EffectToggleNode("dof", "DOF 景深");
+        n.addInput("focalDistance", PortType.FLOAT, 10.0f).setRange(0.5f, 100.0f);
+        n.addInput("focalLength", PortType.FLOAT, 50.0f).setRange(10.0f, 200.0f);
+        n.addInput("aperture", PortType.FLOAT, 2.8f).setRange(1.0f, 22.0f);
+        n.addInput("maxBlur", PortType.FLOAT, 4.0f).setRange(1.0f, 16.0f);
+        return n;
+    }
+
+    /** Motion Blur 動態模糊 — Camera/Object Motion Blur */
+    public static EffectToggleNode createMotionBlur() {
+        EffectToggleNode n = new EffectToggleNode("motion_blur", "Motion Blur 動態模糊");
+        n.addInput("intensity", PortType.FLOAT, 0.5f).setRange(0.0f, 2.0f);
+        n.addInput("samples", PortType.INT, 8).setRange(2, 32);
+        n.addInput("maxVelocity", PortType.FLOAT, 40.0f).setRange(5.0f, 100.0f);
+        return n;
+    }
+
+    /** Contact Shadow 接觸陰影 — Screen-Space Contact Shadows */
+    public static EffectToggleNode createContactShadow() {
+        EffectToggleNode n = new EffectToggleNode("contact_shadow", "Contact Shadow 接觸陰影");
+        n.addInput("rayLength", PortType.FLOAT, 0.15f).setRange(0.01f, 0.5f);
+        n.addInput("raySteps", PortType.INT, 16).setRange(4, 64);
+        n.addInput("fadeDistance", PortType.FLOAT, 20.0f).setRange(5.0f, 50.0f);
+        return n;
+    }
+
+    /** SSGI 螢幕空間全局照明 — Screen-Space Global Illumination */
+    public static EffectToggleNode createSSGI() {
+        EffectToggleNode n = new EffectToggleNode("ssgi", "SSGI 螢幕空間全局照明");
+        n.addInput("samples", PortType.INT, 16).setRange(4, 64);
+        n.addInput("radius", PortType.FLOAT, 3.0f).setRange(0.5f, 10.0f);
+        n.addInput("intensity", PortType.FLOAT, 1.0f).setRange(0.0f, 5.0f);
+        n.addInput("bounces", PortType.INT, 1).setRange(1, 4);
+        return n;
+    }
+
+    /** VCT 體素錐追蹤 — Voxel Cone Tracing */
+    public static EffectToggleNode createVCT() {
+        EffectToggleNode n = new EffectToggleNode("vct", "VCT 體素錐追蹤");
+        n.addInput("resolution", PortType.INT, 128).setRange(32, 512);
+        n.addInput("coneAngle", PortType.FLOAT, 0.5f).setRange(0.1f, 1.5f);
+        n.addInput("traceDistance", PortType.FLOAT, 64.0f).setRange(8.0f, 256.0f);
+        n.addInput("giIntensity", PortType.FLOAT, 1.0f).setRange(0.0f, 5.0f);
+        return n;
+    }
+
+    /** SSS 次表面散射 — Subsurface Scattering */
+    public static EffectToggleNode createSSS() {
+        EffectToggleNode n = new EffectToggleNode("sss", "SSS 次表面散射");
+        n.addInput("scatterRadius", PortType.FLOAT, 1.0f).setRange(0.1f, 5.0f);
+        n.addInput("intensity", PortType.FLOAT, 1.0f).setRange(0.0f, 3.0f);
+        n.addInput("samples", PortType.INT, 16).setRange(4, 64);
+        return n;
+    }
+
+    /** Anisotropic 各向異性反射 — Anisotropic Reflections */
+    public static EffectToggleNode createAnisotropic() {
+        EffectToggleNode n = new EffectToggleNode("anisotropic", "Anisotropic 各向異性反射");
+        n.addInput("anisotropy", PortType.FLOAT, 0.5f).setRange(0.0f, 1.0f);
+        n.addInput("roughnessScale", PortType.FLOAT, 1.0f).setRange(0.1f, 2.0f);
+        return n;
+    }
+
+    /** POM 視差遮蔽貼圖 — Parallax Occlusion Mapping */
+    public static EffectToggleNode createPOM() {
+        EffectToggleNode n = new EffectToggleNode("pom", "POM 視差遮蔽貼圖");
+        n.addInput("heightScale", PortType.FLOAT, 0.05f).setRange(0.01f, 0.2f);
+        n.addInput("layers", PortType.INT, 32).setRange(8, 128);
+        n.addInput("refinementSteps", PortType.INT, 5).setRange(1, 16);
+        return n;
+    }
+
+    // ═══════════════════════════════════════════════════════
+    //  評估
+    // ═══════════════════════════════════════════════════════
+
+    @Override
+    public void evaluate() {
+        boolean enabled = getBool("enabled");
+        setOutput("enabled", enabled);
+        setOutput("effectName", effectName);
+
+        // Forward effect-specific outputs when enabled
+        if (enabled) {
+            // SSAO: forward kernelSize as samples output
+            if ("ssao".equals(effectName)) {
+                NodePort kernelPort = getInput("kernelSize");
+                if (kernelPort != null && kernelPort.getValue() != null) {
+                    setOutput("samples", ((Number) kernelPort.getValue()).intValue());
+                }
+            }
+        } else {
+            // When disabled, zero out numeric outputs
+            NodePort samplesOutput = getOutput("samples");
+            if (samplesOutput != null) {
+                setOutput("samples", 0);
+            }
+        }
+    }
+
+    /**
+     * 取得此節點代表的效果名稱。
+     *
+     * @return effect identifier (e.g. "ssao", "ssr", "bloom")
+     */
+    public String getEffectName() {
+        return effectName;
+    }
+}

--- a/Block Reality/api/src/main/java/com/blockreality/api/node/nodes/render/QualityPresetNode.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/node/nodes/render/QualityPresetNode.java
@@ -1,0 +1,195 @@
+package com.blockreality.api.node.nodes.render;
+
+import com.blockreality.api.node.BRNode;
+import com.blockreality.api.node.PortType;
+
+/**
+ * A1-1 品質預設節點 — 一鍵品質預設，扇出 20+ 個布林/整數輸出。
+ *
+ * 選擇預設等級後，自動設定所有渲染子系統的開關與品質參數。
+ * 預設等級：Potato(0), Low(1), Medium(2), High(3), Ultra(4), Custom(5)。
+ *
+ * Custom 模式下不覆寫任何輸出，保留上游連線的值。
+ */
+public class QualityPresetNode extends BRNode {
+
+    public static final int NODE_COLOR = 0x2196F3; // Blue
+
+    public QualityPresetNode() {
+        super("品質預設 QualityPreset", "render", NODE_COLOR);
+
+        // Input: preset selection (0=Potato, 1=Low, 2=Medium, 3=High, 4=Ultra, 5=Custom)
+        addInput("preset", PortType.INT, 3); // default: High
+
+        // Outputs: fan out to all render subsystems
+        addOutput("shadowRes", PortType.INT);
+        addOutput("ssaoEnabled", PortType.BOOL);
+        addOutput("ssrEnabled", PortType.BOOL);
+        addOutput("ssgiEnabled", PortType.BOOL);
+        addOutput("taaEnabled", PortType.BOOL);
+        addOutput("bloomEnabled", PortType.BOOL);
+        addOutput("dofEnabled", PortType.BOOL);
+        addOutput("volumetricEnabled", PortType.BOOL);
+        addOutput("contactShadowEnabled", PortType.BOOL);
+        addOutput("motionBlurEnabled", PortType.BOOL);
+        addOutput("cloudEnabled", PortType.BOOL);
+        addOutput("weatherEnabled", PortType.BOOL);
+        addOutput("waterEnabled", PortType.BOOL);
+        addOutput("fogEnabled", PortType.BOOL);
+        addOutput("atmosphereEnabled", PortType.BOOL);
+        addOutput("sssEnabled", PortType.BOOL);
+        addOutput("anisotropicEnabled", PortType.BOOL);
+        addOutput("pomEnabled", PortType.BOOL);
+        addOutput("vctEnabled", PortType.BOOL);
+        addOutput("rtShadowEnabled", PortType.BOOL);
+        addOutput("ssaoSamples", PortType.INT);
+        addOutput("lodMaxDistance", PortType.FLOAT);
+    }
+
+    @Override
+    public void evaluate() {
+        int preset = getInt("preset");
+
+        switch (preset) {
+            case 0 -> applyPotato();
+            case 1 -> applyLow();
+            case 2 -> applyMedium();
+            case 3 -> applyHigh();
+            case 4 -> applyUltra();
+            case 5 -> {
+                // Custom: don't change outputs — leave wired values intact
+            }
+            default -> applyHigh(); // fallback to High
+        }
+    }
+
+    /** Potato — 最低畫質，極限效能 */
+    private void applyPotato() {
+        setOutput("shadowRes", 512);
+        setOutput("ssaoEnabled", false);
+        setOutput("ssrEnabled", false);
+        setOutput("ssgiEnabled", false);
+        setOutput("taaEnabled", false);
+        setOutput("bloomEnabled", false);
+        setOutput("dofEnabled", false);
+        setOutput("volumetricEnabled", false);
+        setOutput("contactShadowEnabled", false);
+        setOutput("motionBlurEnabled", false);
+        setOutput("cloudEnabled", false);
+        setOutput("weatherEnabled", false);
+        setOutput("waterEnabled", false);
+        setOutput("fogEnabled", true);
+        setOutput("atmosphereEnabled", false);
+        setOutput("sssEnabled", false);
+        setOutput("anisotropicEnabled", false);
+        setOutput("pomEnabled", false);
+        setOutput("vctEnabled", false);
+        setOutput("rtShadowEnabled", false);
+        setOutput("ssaoSamples", 8);
+        setOutput("lodMaxDistance", 128.0f);
+    }
+
+    /** Low — 基礎效果，適合低端硬體 */
+    private void applyLow() {
+        setOutput("shadowRes", 1024);
+        setOutput("ssaoEnabled", true);
+        setOutput("ssrEnabled", false);
+        setOutput("ssgiEnabled", false);
+        setOutput("taaEnabled", false);
+        setOutput("bloomEnabled", true);
+        setOutput("dofEnabled", false);
+        setOutput("volumetricEnabled", false);
+        setOutput("contactShadowEnabled", false);
+        setOutput("motionBlurEnabled", false);
+        setOutput("cloudEnabled", false);
+        setOutput("weatherEnabled", true);
+        setOutput("waterEnabled", true);
+        setOutput("fogEnabled", true);
+        setOutput("atmosphereEnabled", false);
+        setOutput("sssEnabled", false);
+        setOutput("anisotropicEnabled", false);
+        setOutput("pomEnabled", false);
+        setOutput("vctEnabled", false);
+        setOutput("rtShadowEnabled", false);
+        setOutput("ssaoSamples", 16);
+        setOutput("lodMaxDistance", 256.0f);
+    }
+
+    /** Medium — 平衡畫質與效能 */
+    private void applyMedium() {
+        setOutput("shadowRes", 2048);
+        setOutput("ssaoEnabled", true);
+        setOutput("ssrEnabled", false);
+        setOutput("ssgiEnabled", false);
+        setOutput("taaEnabled", true);
+        setOutput("bloomEnabled", true);
+        setOutput("dofEnabled", false);
+        setOutput("volumetricEnabled", false);
+        setOutput("contactShadowEnabled", true);
+        setOutput("motionBlurEnabled", false);
+        setOutput("cloudEnabled", true);
+        setOutput("weatherEnabled", true);
+        setOutput("waterEnabled", true);
+        setOutput("fogEnabled", true);
+        setOutput("atmosphereEnabled", true);
+        setOutput("sssEnabled", false);
+        setOutput("anisotropicEnabled", false);
+        setOutput("pomEnabled", false);
+        setOutput("vctEnabled", false);
+        setOutput("rtShadowEnabled", false);
+        setOutput("ssaoSamples", 24);
+        setOutput("lodMaxDistance", 512.0f);
+    }
+
+    /** High — 高品質，推薦設定 */
+    private void applyHigh() {
+        setOutput("shadowRes", 2048);
+        setOutput("ssaoEnabled", true);
+        setOutput("ssrEnabled", true);
+        setOutput("ssgiEnabled", true);
+        setOutput("taaEnabled", true);
+        setOutput("bloomEnabled", true);
+        setOutput("dofEnabled", false);
+        setOutput("volumetricEnabled", true);
+        setOutput("contactShadowEnabled", true);
+        setOutput("motionBlurEnabled", false);
+        setOutput("cloudEnabled", true);
+        setOutput("weatherEnabled", true);
+        setOutput("waterEnabled", true);
+        setOutput("fogEnabled", true);
+        setOutput("atmosphereEnabled", true);
+        setOutput("sssEnabled", true);
+        setOutput("anisotropicEnabled", true);
+        setOutput("pomEnabled", true);
+        setOutput("vctEnabled", true);
+        setOutput("rtShadowEnabled", false);
+        setOutput("ssaoSamples", 32);
+        setOutput("lodMaxDistance", 768.0f);
+    }
+
+    /** Ultra — 最高品質，所有效果全開 */
+    private void applyUltra() {
+        setOutput("shadowRes", 4096);
+        setOutput("ssaoEnabled", true);
+        setOutput("ssrEnabled", true);
+        setOutput("ssgiEnabled", true);
+        setOutput("taaEnabled", true);
+        setOutput("bloomEnabled", true);
+        setOutput("dofEnabled", true);
+        setOutput("volumetricEnabled", true);
+        setOutput("contactShadowEnabled", true);
+        setOutput("motionBlurEnabled", true);
+        setOutput("cloudEnabled", true);
+        setOutput("weatherEnabled", true);
+        setOutput("waterEnabled", true);
+        setOutput("fogEnabled", true);
+        setOutput("atmosphereEnabled", true);
+        setOutput("sssEnabled", true);
+        setOutput("anisotropicEnabled", true);
+        setOutput("pomEnabled", true);
+        setOutput("vctEnabled", true);
+        setOutput("rtShadowEnabled", true);
+        setOutput("ssaoSamples", 64);
+        setOutput("lodMaxDistance", 1024.0f);
+    }
+}


### PR DESCRIPTION
節點引擎核心 (com.blockreality.api.node/):
- PortType: 14 種端口型別（FLOAT/INT/BOOL/VEC/MATERIAL/BLOCK 等）含型別相容檢查
- NodePort: 輸入/輸出端口，支援預設值、範圍限制、dirty 傳播
- Wire: 端口連線 + 自動型別轉換（FLOAT↔INT, BOOL→FLOAT, VEC3↔COLOR）
- BRNode: 抽象節點基類（evaluate/markDirty/addInput/addOutput）
- NodeGraph: DAG 管理器 + Kahn's 拓撲排序 + 惰性評估（僅計算 dirty 節點）
- EvaluateScheduler: 每幀 tick 評估活躍節點圖

渲染節點 (nodes/render/):
- QualityPresetNode: A1-1 品質預設（Potato→Ultra 六級，20+ 輸出端口）
- EffectToggleNode: A3 通用效果節點 × 13 工廠方法 createSSAO/SSR/TAA/Bloom/Volumetric/DOF/MotionBlur/ContactShadow/ SSGI/VCT/SSS/Anisotropic/POM — 各含效果專屬參數端口

資料綁定 (binder/):
- RenderConfigBinder: 節點圖輸出 → BRRenderSettings 雙向映射 pushToSettings(): 評估後推送到運行時設定 pullFromSettings(): 初始化時從設定填入節點

序列化 (NodeGraphIO):
- JSON 序列化/反序列化 + 5 個品質預設圖工廠
- saveToFile/loadFromFile + 節點型別註冊系統

BRRenderSettings 整合:
- 啟動時載入 config/blockreality/node_graphs/active_render.json
- 每幀 tick: EvaluateScheduler → syncFromNodeGraph()
- applyStyle() 同步更新節點圖
- 關閉時自動保存節點圖

https://claude.ai/code/session_01UJXWS32encknhPFLNECRPD