### PR TITLE
🧹 Remove unused import in CableStateTest

### DIFF
--- a/Block Reality/api/src/test/java/com/blockreality/api/physics/CableStateTest.java
+++ b/Block Reality/api/src/test/java/com/blockreality/api/physics/CableStateTest.java
@@ -2,7 +2,6 @@ package com.blockreality.api.physics;
 
 import com.blockreality.api.material.DefaultMaterial;
 import net.minecraft.core.BlockPos;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
🎯 **What:** Removed the unused `org.junit.jupiter.api.BeforeEach` import in `CableStateTest.java`.
💡 **Why:** Removing unused imports reduces clutter and improves readability and code health.
✅ **Verification:** Verified the removal in the source file using `read_file` and code review. Running tests wasn't entirely successful due to other pre-existing compilation errors in the codebase, but the import removal itself is verified to be safe.
✨ **Result:** Improved maintainability and hygiene in the `CableStateTest` class.

---
*PR created automatically by Jules for task [3117460598299622126](https://jules.google.com/task/3117460598299622126) started by @rocky59487*