### PR TITLE
🛡️ Sentinel: [HIGH] Fix packet flooding DoS vulnerability

### DIFF
--- a/Block Reality/fastdesign/src/main/java/com/blockreality/fastdesign/network/FdActionPacket.java
+++ b/Block Reality/fastdesign/src/main/java/com/blockreality/fastdesign/network/FdActionPacket.java
@@ -136,10 +136,7 @@ public class FdActionPacket {
     public static void handle(FdActionPacket pkt, Supplier<NetworkEvent.Context> ctx) {
         ctx.get().enqueueWork(() -> {
             ServerPlayer player = ctx.get().getSender();
-            if (player == null) {
-                LOGGER.warn("FdActionPacket received but no player associated");
-                return;
-            }
+            if (!com.blockreality.api.network.BRNetwork.validateSender(player, "FdActionPacket")) return;
 
             ServerLevel level = player.serverLevel();
             if (level == null) {

--- a/Block Reality/fastdesign/src/main/java/com/blockreality/fastdesign/network/PastePlacePacket.java
+++ b/Block Reality/fastdesign/src/main/java/com/blockreality/fastdesign/network/PastePlacePacket.java
@@ -58,7 +58,7 @@ public class PastePlacePacket {
         NetworkEvent.Context ctx = ctxSupplier.get();
         ctx.enqueueWork(() -> {
             ServerPlayer player = ctx.getSender();
-            if (player == null) return;
+            if (!com.blockreality.api.network.BRNetwork.validateSender(player, "PastePlacePacket")) return;
             ServerLevel level = player.serverLevel();
 
             // 權限檢查


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix packet flooding DoS vulnerability

**Severity:** HIGH
**Vulnerability:** Found missing packet sender validation in Fast Design network packets (`FdActionPacket`, `PastePlacePacket`). This allows malicious clients to flood the server with action/place requests without any rate limiting or payload restriction, leading to a Denial of Service (DoS) and potential OOM.
**Impact:** A malicious user could continuously send these packets, overwhelming the server.
**Fix:** Added `BRNetwork.validateSender` calls in `handle` to enforce frequency limits and perform basic validation.
**Verification:** The validation logic is already tested and proven in `ChiselControlPacket`.

---
*PR created automatically by Jules for task [12593085098161016536](https://jules.google.com/task/12593085098161016536) started by @rocky59487*