### PR TITLE
Fix Chisel rendering and client synchronization

### DIFF
--- a/Block Reality/api/src/main/java/com/blockreality/api/client/ClientSetup.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/client/ClientSetup.java
@@ -19,8 +19,12 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.event.level.LevelEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.client.event.EntityRenderersEvent;
 import net.minecraftforge.fml.common.Mod;
 import org.lwjgl.glfw.GLFW;
+
+import com.blockreality.api.client.render.RBlockEntityRenderer;
+import com.blockreality.api.registry.BRBlockEntities;
 
 /**
  * 客戶端初始化 — v3fix §1.8
@@ -53,6 +57,14 @@ public class ClientSetup {
     @SubscribeEvent
     public static void onRegisterKeyMappings(RegisterKeyMappingsEvent event) {
         event.register(STRESS_OVERLAY_KEY);
+    }
+
+    /**
+     * MOD bus: 註冊 BlockEntityRenderers
+     */
+    @SubscribeEvent
+    public static void onRegisterRenderers(EntityRenderersEvent.RegisterRenderers event) {
+        event.registerBlockEntityRenderer(BRBlockEntities.R_BLOCK_ENTITY.get(), RBlockEntityRenderer::new);
     }
 
     /**

--- a/Block Reality/api/src/main/java/com/blockreality/api/client/render/ChiselMeshBuilder.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/client/render/ChiselMeshBuilder.java
@@ -1,4 +1,4 @@
-package com.blockreality.fastdesign.client;
+package com.blockreality.api.client.render;
 
 import com.blockreality.api.chisel.VoxelGrid;
 import com.mojang.blaze3d.vertex.PoseStack;

--- a/Block Reality/api/src/main/java/com/blockreality/api/client/render/RBlockEntityRenderer.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/client/render/RBlockEntityRenderer.java
@@ -1,0 +1,36 @@
+package com.blockreality.api.client.render;
+
+import com.blockreality.api.block.RBlockEntity;
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
+import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
+
+public class RBlockEntityRenderer implements BlockEntityRenderer<RBlockEntity> {
+
+    public RBlockEntityRenderer(BlockEntityRendererProvider.Context context) {
+    }
+
+    @Override
+    public void render(RBlockEntity blockEntity, float partialTick, PoseStack poseStack,
+                       MultiBufferSource bufferSource, int packedLight, int packedOverlay) {
+        if (!blockEntity.getChiselState().isFull()) {
+            int r = 255;
+            int g = 255;
+            int b = 255;
+            int a = 255;
+
+            poseStack.pushPose();
+
+            com.blockreality.api.client.render.ChiselMeshBuilder.renderVoxelGrid(
+                blockEntity.getChiselState().voxelGrid(),
+                poseStack,
+                bufferSource,
+                r, g, b, a,
+                packedLight
+            );
+
+            poseStack.popPose();
+        }
+    }
+}

--- a/Block Reality/api/src/main/java/com/blockreality/api/client/render/rt/BRVulkanRT.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/client/render/rt/BRVulkanRT.java
@@ -1829,4 +1829,6 @@ public final class BRVulkanRT {
                                                     long raygenModule, long missModule,
                                                     long chitModule, long ahitModule) {
         return BRVulkanDevice.createRayTracingPipelineWithAnyHit(device, pipelineLayout,
-                raygenModule, missModule, chitModule, ahitModu
+                raygenModule, missModule, chitModule, ahitModule);
+    }
+}

--- a/Block Reality/fastdesign/src/main/java/com/blockreality/fastdesign/client/ChiselToolScreen.java
+++ b/Block Reality/fastdesign/src/main/java/com/blockreality/fastdesign/client/ChiselToolScreen.java
@@ -99,7 +99,18 @@ public class ChiselToolScreen extends Screen {
     }
 
     private void selectShape(SubBlockShape shape) {
-        // 透過 ChiselControlPacket 發送形狀選擇
+        // 更新客戶端自己的 ItemStack 狀態，確保預測渲染與 tooltip 正確
+        if (this.minecraft != null && this.minecraft.player != null) {
+            net.minecraft.world.item.ItemStack main = this.minecraft.player.getMainHandItem();
+            net.minecraft.world.item.ItemStack off = this.minecraft.player.getOffhandItem();
+            if (main.getItem() instanceof ChiselItem) {
+                ChiselItem.setShapeByName(main, shape);
+            } else if (off.getItem() instanceof ChiselItem) {
+                ChiselItem.setShapeByName(off, shape);
+            }
+        }
+
+        // 透過 ChiselControlPacket 發送形狀選擇同步給伺服器
         BRNetwork.CHANNEL.sendToServer(
             new ChiselControlPacket(ChiselControlPacket.Action.SELECT_SHAPE,
                 shape.getSerializedName()));

--- a/Block Reality/fastdesign/src/main/java/com/blockreality/fastdesign/client/FdKeyBindings.java
+++ b/Block Reality/fastdesign/src/main/java/com/blockreality/fastdesign/client/FdKeyBindings.java
@@ -336,22 +336,34 @@ public class FdKeyBindings {
                 mc.player.getMainHandItem().getItem() instanceof ChiselItem ||
                 mc.player.getOffhandItem().getItem() instanceof ChiselItem;
 
+            // ─── 輔助方法：獲取當前手持的雕刻刀並更新客戶端 NBT ───
+            net.minecraft.world.item.ItemStack chiselStack = null;
+            if (mc.player.getMainHandItem().getItem() instanceof ChiselItem) {
+                chiselStack = mc.player.getMainHandItem();
+            } else if (mc.player.getOffhandItem().getItem() instanceof ChiselItem) {
+                chiselStack = mc.player.getOffhandItem();
+            }
+
             // ─── 上下鍵：調高度 ───
             while (TOOL_HEIGHT_UP.consumeClick()) {
+                if (chiselStack != null) ChiselItem.adjustSelectionHeight(chiselStack, 1);
                 BRNetwork.CHANNEL.sendToServer(
                     new ChiselControlPacket(ChiselControlPacket.Action.SEL_HEIGHT_INC));
             }
             while (TOOL_HEIGHT_DOWN.consumeClick()) {
+                if (chiselStack != null) ChiselItem.adjustSelectionHeight(chiselStack, -1);
                 BRNetwork.CHANNEL.sendToServer(
                     new ChiselControlPacket(ChiselControlPacket.Action.SEL_HEIGHT_DEC));
             }
 
             // ─── 左右鍵：調寬度 ───
             while (TOOL_WIDTH_RIGHT.consumeClick()) {
+                if (chiselStack != null) ChiselItem.adjustSelectionWidth(chiselStack, 1);
                 BRNetwork.CHANNEL.sendToServer(
                     new ChiselControlPacket(ChiselControlPacket.Action.SEL_WIDTH_INC));
             }
             while (TOOL_WIDTH_LEFT.consumeClick()) {
+                if (chiselStack != null) ChiselItem.adjustSelectionWidth(chiselStack, -1);
                 BRNetwork.CHANNEL.sendToServer(
                     new ChiselControlPacket(ChiselControlPacket.Action.SEL_WIDTH_DEC));
             }
@@ -359,6 +371,11 @@ public class FdKeyBindings {
             // ─── H 鍵：邊長（寬高同時調整），Shift+H 縮小 ───
             while (TOOL_EDGE_LENGTH.consumeClick()) {
                 boolean shrink = net.minecraft.client.gui.screens.Screen.hasShiftDown();
+                if (chiselStack != null) {
+                    int delta = shrink ? -1 : 1;
+                    ChiselItem.adjustSelectionWidth(chiselStack, delta);
+                    ChiselItem.adjustSelectionHeight(chiselStack, delta);
+                }
                 ChiselControlPacket.Action edgeAction = shrink
                     ? ChiselControlPacket.Action.EDGE_LENGTH_DEC
                     : ChiselControlPacket.Action.EDGE_LENGTH_INC;
@@ -368,9 +385,11 @@ public class FdKeyBindings {
             // ─── X 鍵：按住 = 橡皮擦模式（邊緣觸發） ───
             boolean isEraseDown = TOOL_ERASE.isDown();
             if (isEraseDown && !wasEraseKeyDown) {
+                if (chiselStack != null) ChiselItem.setEraseMode(chiselStack, true);
                 BRNetwork.CHANNEL.sendToServer(
                     new ChiselControlPacket(ChiselControlPacket.Action.ERASE_ON));
             } else if (!isEraseDown && wasEraseKeyDown) {
+                if (chiselStack != null) ChiselItem.setEraseMode(chiselStack, false);
                 BRNetwork.CHANNEL.sendToServer(
                     new ChiselControlPacket(ChiselControlPacket.Action.ERASE_OFF));
             }


### PR DESCRIPTION
The Chisel system was reported to be completely unresponsive and micro-voxels were never visible.
The root causes were:
1. `ChiselMeshBuilder` was never wired to a `BlockEntityRenderer`, so non-full blocks continued to be rendered using the default block model (`RBlock` returns `RenderShape.MODEL`).
2. Client-side predictions and UI tooltips failed because `ChiselToolScreen` and `FdKeyBindings` sent packets to the server but never updated the local client `ItemStack` NBT, causing the shape to stay "FULL" in the UI.

Fixes:
- Added `RBlockEntityRenderer` and registered it in `ClientSetup` to render `ChiselMeshBuilder.renderVoxelGrid()`.
- Moved `ChiselMeshBuilder` from the `fastdesign` module to the `api` module so the base renderer could access it.
- Patched `ChiselToolScreen` and `FdKeyBindings` to update the player's main/offhand `ItemStack` NBT locally upon executing Chisel actions.
- Fixed a pre-existing syntax error `ahitModu` in `BRVulkanRT.java`.

---
*PR created automatically by Jules for task [8873807933747939338](https://jules.google.com/task/8873807933747939338) started by @rocky59487*