### PR TITLE
fix: PFSFVCycleRecorderTest 斷言邏輯錯誤

### DIFF
--- a/Block Reality/api/src/test/java/com/blockreality/api/physics/pfsf/PFSFVCycleRecorderTest.java
+++ b/Block Reality/api/src/test/java/com/blockreality/api/physics/pfsf/PFSFVCycleRecorderTest.java
@@ -40,8 +40,8 @@ class PFSFVCycleRecorderTest {
             if (k == 4 || k == 8 || k == 12 || k == 16) {
                 assertTrue(shouldVCycle, "V-Cycle should trigger at step " + k);
             } else {
-                assertFalse(shouldVCycle || k == 0,
-                        "V-Cycle should NOT trigger at step " + k + " (only at multiples of " + PFSFConstants.MG_INTERVAL + " > 0)");
+                assertFalse(shouldVCycle,
+                        "V-Cycle should NOT trigger at step " + k);
             }
         }
     }


### PR DESCRIPTION
k==0 時 shouldVCycle=false 但 (shouldVCycle || k==0) = true， assertFalse(true) 失敗。移除多餘的 k==0 條件。

https://claude.ai/code/session_018Gr3ZonaKstpoVtPTTJoCW