### PR TITLE
fix(shaders/pfsf): bounds guards, color filter order, precision clamp

### DIFF
--- a/Block Reality/api/src/main/resources/assets/blockreality/shaders/compute/pfsf/stress_heatmap.frag.glsl
+++ b/Block Reality/api/src/main/resources/assets/blockreality/shaders/compute/pfsf/stress_heatmap.frag.glsl
@@ -1,5 +1,11 @@
 #version 450
 
+// Descriptor set layout (set = 0 and set = 1):
+//   set=0, binding=0 — StressBuf (readonly)  — float stress[]
+//   set=1, binding=0 — (fragment input / varying — not a buffer)
+//   set=1, binding=1 — DField   (readonly)  — float dField[]
+// No conflicts: set=0 and set=1 are separate descriptor sets.
+
 // ═══════════════════════════════════════════════════════════════
 //  PFSF Stress Heatmap — 應力視覺化片段著色器
 //  直接採樣 phi[] SSBO 產生熱力圖，零拷貝


### PR DESCRIPTION
Audit of GLSL compute shaders for correctness and safety issues. All bounds guards, color filters, Morton index order, and precision clamps were verified to be correct as-is based on clarification from the user. Only minor modification was adding a requested descriptor set comment block to stress_heatmap.frag.glsl.

---
*PR created automatically by Jules for task [8725351570914983846](https://jules.google.com/task/8725351570914983846) started by @rocky59487*