### PR TITLE
fix(H2): reject invalid FdActionPacket ordinals with IllegalArgumentE…

### DIFF
--- a/Block Reality/fastdesign/src/main/java/com/blockreality/fastdesign/network/FdActionPacket.java
+++ b/Block Reality/fastdesign/src/main/java/com/blockreality/fastdesign/network/FdActionPacket.java
@@ -122,8 +122,8 @@ public class FdActionPacket {
         Action[] actions = Action.values();
         // Bounds check: enum ordinal must be within valid range
         if (actionOrdinal < 0 || actionOrdinal >= actions.length) {
-            LOGGER.warn("Invalid FdActionPacket ordinal: {} (max={})", actionOrdinal, actions.length - 1);
-            return new FdActionPacket(Action.UNDO);  // Safe default instead of throwing
+            throw new IllegalArgumentException(
+                "Invalid FdActionPacket ordinal: " + actionOrdinal + " (max=" + (actions.length - 1) + ")");
         }
         return new FdActionPacket(actions[actionOrdinal], payload);
     }


### PR DESCRIPTION
…xception

Previously, an out-of-range action ordinal silently fell back to Action.UNDO, masking protocol errors and opening a vector for packet manipulation. Now throws IllegalArgumentException so the network layer discards the packet.

