### PR TITLE
fix(installer): comprehensive Java 17 detection across all three inst…

### DIFF
--- a/install/quick-install.bat
+++ b/install/quick-install.bat
@@ -1,4 +1,5 @@
 @echo off
+setlocal EnableDelayedExpansion
 chcp 65001 >nul 2>&1
 :: Block Reality v0.1.0-alpha - Quick Install Launcher
 :: This wrapper launches the PowerShell installer for full functionality.
@@ -22,16 +23,72 @@ echo  GPU Structural Physics for MC 1.20.1
 echo ========================================
 echo.
 
-:: Check Java
+:: Check Java 17 — search PATH, JAVA_HOME, and common vendor directories
 echo [1/4] Checking Java 17...
+set "JAVA_EXE="
+
+:: 1. PATH
 java -version 2>&1 | findstr /i "17\." >nul 2>&1
-if %errorLevel% neq 0 (
-    echo [X] Java 17 not found!
-    echo     Download: https://adoptium.net/
-    pause
-    exit /b 1
+if %errorLevel% equ 0 (
+    set "JAVA_EXE=java"
+    goto :java_found
 )
-echo [OK] Java 17 found.
+
+:: 2. JAVA_HOME
+if defined JAVA_HOME (
+    if exist "%JAVA_HOME%\bin\java.exe" (
+        "%JAVA_HOME%\bin\java.exe" -version 2>&1 | findstr /i "17\." >nul 2>&1
+        if !errorLevel! equ 0 (
+            set "JAVA_EXE=%JAVA_HOME%\bin\java.exe"
+            set "PATH=%JAVA_HOME%\bin;%PATH%"
+            goto :java_found
+        )
+    )
+)
+
+:: 3. Common vendor directories under Program Files
+for %%B in ("%ProgramFiles%" "%ProgramFiles(x86)%") do (
+    for %%D in (
+        "Eclipse Adoptium" "Microsoft" "Java" "Amazon Corretto"
+        "BellSoft" "Zulu" "OpenLogic" "SapMachine" "GraalVM"
+    ) do (
+        if exist "%%~B\%%~D\" (
+            for /d %%J in ("%%~B\%%~D\*17*") do (
+                if exist "%%J\bin\java.exe" (
+                    "%%J\bin\java.exe" -version 2>&1 | findstr /i "17\." >nul 2>&1
+                    if !errorLevel! equ 0 (
+                        set "JAVA_EXE=%%J\bin\java.exe"
+                        set "JAVA_HOME=%%J"
+                        set "PATH=%%J\bin;%PATH%"
+                        goto :java_found
+                    )
+                )
+            )
+        )
+    )
+)
+
+:: 4. Direct glob under Program Files
+for /d %%J in ("%ProgramFiles%\*jdk*17*" "%ProgramFiles%\*jre*17*" "%ProgramFiles%\*java*17*") do (
+    if exist "%%J\bin\java.exe" (
+        "%%J\bin\java.exe" -version 2>&1 | findstr /i "17\." >nul 2>&1
+        if !errorLevel! equ 0 (
+            set "JAVA_EXE=%%J\bin\java.exe"
+            set "JAVA_HOME=%%J"
+            set "PATH=%%J\bin;%PATH%"
+            goto :java_found
+        )
+    )
+)
+
+echo [X] Java 17 not found!
+echo     Checked: PATH, JAVA_HOME, Program Files (Adoptium/Microsoft/Corretto/Zulu/BellSoft)
+echo     Download: https://adoptium.net/
+pause
+exit /b 1
+
+:java_found
+echo [OK] Java 17 found: %JAVA_EXE%
 echo.
 
 :: Locate .minecraft

--- a/install/quick-install.ps1
+++ b/install/quick-install.ps1
@@ -48,20 +48,137 @@ Write-Host '  ================================================' -ForegroundColor
 Write-Host ''
 
 # ============================================================
-#  [1/5] Java 17
+#  Java 17 Detection — multi-source search
 # ============================================================
+function Find-Java17 {
+    # Returns the full path to a java.exe that reports version 17, or $null.
+
+    # Helper: test if a given java.exe is version 17
+    function Test-Java17 ([string]$JavaExe) {
+        if (-not (Test-Path $JavaExe)) { return $false }
+        try {
+            $ver = & "$JavaExe" -version 2>&1
+            return ($ver | Select-String '17\.' | Measure-Object).Count -gt 0
+        } catch { return $false }
+    }
+
+    # 1. PATH / default
+    $pathJava = (Get-Command java -ErrorAction SilentlyContinue)?.Source
+    if ($pathJava -and (Test-Java17 $pathJava)) { return $pathJava }
+
+    # 2. JAVA_HOME env var
+    if ($env:JAVA_HOME) {
+        $j = Join-Path $env:JAVA_HOME 'bin\java.exe'
+        if (Test-Java17 $j) { return $j }
+    }
+
+    # 3. Registry — JavaSoft (Oracle/OpenJDK installers)
+    foreach ($regPath in @(
+        'HKLM:\SOFTWARE\JavaSoft\JDK',
+        'HKLM:\SOFTWARE\WOW6432Node\JavaSoft\JDK',
+        'HKLM:\SOFTWARE\JavaSoft\Java Runtime Environment',
+        'HKLM:\SOFTWARE\WOW6432Node\JavaSoft\Java Runtime Environment'
+    )) {
+        if (Test-Path $regPath) {
+            Get-ChildItem $regPath -ErrorAction SilentlyContinue |
+                Where-Object { $_.PSChildName -like '17*' } |
+                ForEach-Object {
+                    $home = (Get-ItemProperty $_.PSPath -ErrorAction SilentlyContinue).JavaHome
+                    if ($home) {
+                        $j = Join-Path $home 'bin\java.exe'
+                        if (Test-Java17 $j) { return $j }
+                    }
+                }
+        }
+    }
+
+    # 4. Well-known vendor install directories under Program Files
+    $pf64 = $env:ProgramFiles
+    $pf86 = ${env:ProgramFiles(x86)}
+    $candidates = @()
+    foreach ($base in @($pf64, $pf86) | Where-Object { $_ }) {
+        $candidates += @(
+            # Eclipse Temurin / Adoptium
+            (Join-Path $base 'Eclipse Adoptium'),
+            # Microsoft Build of OpenJDK
+            (Join-Path $base 'Microsoft'),
+            # Oracle / OpenJDK
+            (Join-Path $base 'Java'),
+            # Amazon Corretto
+            (Join-Path $base 'Amazon Corretto'),
+            # BellSoft Liberica
+            (Join-Path $base 'BellSoft'),
+            # Azul Zulu
+            (Join-Path $base 'Zulu'),
+            # OpenLogic OpenJDK
+            (Join-Path $base 'OpenLogic'),
+            # SAP Machine
+            (Join-Path $base 'SapMachine'),
+            # GraalVM
+            (Join-Path $base 'GraalVM')
+        )
+    }
+    foreach ($dir in $candidates) {
+        if (-not (Test-Path $dir)) { continue }
+        Get-ChildItem $dir -Directory -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -match '(?i)17' } |
+            ForEach-Object {
+                $j = Join-Path $_.FullName 'bin\java.exe'
+                if (Test-Java17 $j) { return $j }
+            }
+    }
+
+    # 5. Glob all JDK/JRE 17 dirs directly under Program Files
+    foreach ($base in @($pf64, $pf86) | Where-Object { $_ }) {
+        Get-ChildItem $base -Directory -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -match '(?i)(jdk|jre|java|openjdk).*(17|temurin.17)' } |
+            ForEach-Object {
+                $j = Join-Path $_.FullName 'bin\java.exe'
+                if (Test-Java17 $j) { return $j }
+            }
+    }
+
+    # 6. Minecraft Launcher bundled Java runtime (users often have this)
+    $mcRuntimes = Join-Path $env:ProgramFiles 'Minecraft Launcher\runtime'
+    if (-not (Test-Path $mcRuntimes)) {
+        $mcRuntimes = Join-Path $env:LOCALAPPDATA 'Packages\Microsoft.4297127D64EC6_8wekyb3d8bbwe\LocalCache\Local\runtime'
+    }
+    if (Test-Path $mcRuntimes) {
+        Get-ChildItem $mcRuntimes -Recurse -Filter 'java.exe' -ErrorAction SilentlyContinue |
+            ForEach-Object {
+                if (Test-Java17 $_.FullName) { return $_.FullName }
+            }
+    }
+
+    # 7. SDKMan (WSL/Git Bash users sometimes expose via Windows path)
+    $sdkman = Join-Path $env:USERPROFILE '.sdkman\candidates\java'
+    if (Test-Path $sdkman) {
+        Get-ChildItem $sdkman -Directory -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -like '17*' } |
+            ForEach-Object {
+                $j = Join-Path $_.FullName 'bin\java.exe'
+                if (Test-Java17 $j) { return $j }
+            }
+    }
+
+    return $null
+}
+
 Write-Step '1/5' 'Java 17 ...'
 
-$javaOk = $false
-try {
-    $javaVer = & java -version 2>&1 | Select-String '17\.'
-    if ($javaVer) { $javaOk = $true }
-} catch {}
+$javaExe = Find-Java17
 
-if ($javaOk) {
-    Write-OK 'Java 17 detected'
+if ($javaExe) {
+    # Prepend this java's bin dir to PATH so Gradle and Forge installer use it
+    $javaDir = Split-Path $javaExe -Parent
+    if ($env:Path -notlike "*$javaDir*") {
+        $env:Path = "$javaDir;$env:Path"
+        Write-Info "Added to PATH: $javaDir"
+    }
+    $env:JAVA_HOME = Split-Path $javaDir -Parent
+    Write-OK "Java 17 detected: $javaExe"
 } else {
-    Write-Fail 'Java 17 not found'
+    Write-Fail 'Java 17 not found (checked PATH, JAVA_HOME, registry, and common install locations)'
     if (Ask-YesNo '       Auto-download Eclipse Temurin 17?') {
         $msiPath = Join-Path $env:TEMP 'temurin17.msi'
         Write-Build "Downloading Temurin 17 JDK ..."
@@ -70,14 +187,17 @@ if ($javaOk) {
             Invoke-WebRequest -Uri $JAVA_MSI_URL -OutFile $msiPath -UseBasicParsing
             Write-Build "Running installer (may require admin) ..."
             Start-Process msiexec.exe -ArgumentList "/i `"$msiPath`" /passive ADDLOCAL=FeatureMain,FeatureJavaHome,FeaturePath" -Wait
-            # Re-check
+            # Reload PATH from registry after install
             $env:Path = [System.Environment]::GetEnvironmentVariable('Path', 'Machine') + ';' +
                         [System.Environment]::GetEnvironmentVariable('Path', 'User')
-            $javaVer2 = & java -version 2>&1 | Select-String '17\.'
-            if ($javaVer2) {
-                Write-OK 'Java 17 installed successfully'
+            $javaExe2 = Find-Java17
+            if ($javaExe2) {
+                $javaDir2 = Split-Path $javaExe2 -Parent
+                $env:Path = "$javaDir2;$env:Path"
+                $env:JAVA_HOME = Split-Path $javaDir2 -Parent
+                Write-OK "Java 17 installed successfully: $javaExe2"
             } else {
-                Write-Warn 'Install finished but java not in PATH yet - restart terminal after install'
+                Write-Warn 'Install finished but java not found yet - restart terminal after install'
             }
         } catch {
             Write-Fail "Download failed: $_"

--- a/install/quick-install.sh
+++ b/install/quick-install.sh
@@ -36,19 +36,108 @@ echo -e "  ${C}================================================${N}"
 echo ""
 
 # ============================================================
+#  Java 17 detection — multi-source search
+# ============================================================
+# Returns the path to a java binary that reports version 17, or empty string.
+find_java17() {
+    local j
+
+    # Helper: test if a binary is Java 17
+    _is_java17() {
+        [[ -x "$1" ]] && "$1" -version 2>&1 | grep -q '17\.'
+    }
+
+    # 1. java already in PATH
+    if command -v java &>/dev/null && _is_java17 "$(command -v java)"; then
+        echo "$(command -v java)"; return 0
+    fi
+
+    # 2. JAVA_HOME
+    if [[ -n "${JAVA_HOME:-}" ]] && _is_java17 "$JAVA_HOME/bin/java"; then
+        echo "$JAVA_HOME/bin/java"; return 0
+    fi
+
+    # 3. update-alternatives (Debian/Ubuntu/RHEL)
+    if command -v update-alternatives &>/dev/null; then
+        local alt
+        alt=$(update-alternatives --list java 2>/dev/null | grep '17' | head -1)
+        if [[ -n "$alt" ]] && _is_java17 "$alt"; then
+            echo "$alt"; return 0
+        fi
+    fi
+
+    # 4. /usr/lib/jvm  (Linux JVM directory)
+    if [[ -d /usr/lib/jvm ]]; then
+        for j in /usr/lib/jvm/java-17*/bin/java \
+                 /usr/lib/jvm/jdk-17*/bin/java \
+                 /usr/lib/jvm/temurin-17*/bin/java \
+                 /usr/lib/jvm/zulu-17*/bin/java \
+                 /usr/lib/jvm/liberica-17*/bin/java; do
+            [[ -x "$j" ]] && _is_java17 "$j" && { echo "$j"; return 0; }
+        done
+        # Fallback: scan any JVM with "17" in name
+        for d in /usr/lib/jvm/*/; do
+            j="${d}bin/java"
+            _is_java17 "$j" && { echo "$j"; return 0; }
+        done
+    fi
+
+    # 5. macOS: /Library/Java/JavaVirtualMachines
+    if [[ -d /Library/Java/JavaVirtualMachines ]]; then
+        for d in /Library/Java/JavaVirtualMachines/*/Contents/Home; do
+            j="$d/bin/java"
+            _is_java17 "$j" && { echo "$j"; return 0; }
+        done
+    fi
+
+    # 6. macOS Homebrew (Intel + Apple Silicon)
+    for j in /usr/local/opt/openjdk@17/bin/java \
+             /opt/homebrew/opt/openjdk@17/bin/java \
+             /opt/homebrew/opt/temurin@17/bin/java; do
+        _is_java17 "$j" && { echo "$j"; return 0; }
+    done
+
+    # 7. SDKMan
+    if [[ -d "${SDKMAN_DIR:-$HOME/.sdkman}/candidates/java" ]]; then
+        local sdk_base="${SDKMAN_DIR:-$HOME/.sdkman}/candidates/java"
+        for d in "$sdk_base"/17*/; do
+            j="$d/bin/java"
+            _is_java17 "$j" && { echo "$j"; return 0; }
+        done
+    fi
+
+    # 8. ASDF
+    if [[ -d "${ASDF_DIR:-$HOME/.asdf}/installs/java" ]]; then
+        for d in "${ASDF_DIR:-$HOME/.asdf}"/installs/java/*17*/; do
+            j="$d/bin/java"
+            _is_java17 "$j" && { echo "$j"; return 0; }
+        done
+    fi
+
+    # 9. Minecraft Launcher bundled JRE (Linux)
+    for d in "$HOME/.minecraft/runtime"/*/ \
+             "$HOME/.local/share/multimc/jars" \
+             "$HOME/.local/share/PrismLauncher/java"/*; do
+        j="$d/bin/java"
+        _is_java17 "$j" && { echo "$j"; return 0; }
+    done
+
+    echo ""; return 1
+}
+
+# ============================================================
 #  [1/5] Java 17
 # ============================================================
 step "1/5" "Java 17 ..."
 
-java_ok=false
-if command -v java &>/dev/null; then
-    if java -version 2>&1 | grep -q '17\.'; then
-        java_ok=true
-    fi
-fi
+JAVA_EXE="$(find_java17)"
 
-if $java_ok; then
-    ok "Java 17 detected"
+if [[ -n "$JAVA_EXE" ]]; then
+    JAVA_BIN_DIR="$(dirname "$JAVA_EXE")"
+    export JAVA_HOME="$(dirname "$JAVA_BIN_DIR")"
+    # Prepend to PATH so Gradle and Forge installer pick this java
+    export PATH="$JAVA_BIN_DIR:$PATH"
+    ok "Java 17 detected: $JAVA_EXE"
 else
     fail "Java 17 not found"
 
@@ -59,7 +148,6 @@ else
                 build "Installing temurin-17-jdk ..."
                 sudo apt update -qq
                 sudo apt install -y temurin-17-jdk 2>/dev/null || {
-                    # Add Adoptium repo if not present
                     build "Adding Adoptium repository ..."
                     sudo mkdir -p /etc/apt/keyrings
                     wget -qO- https://packages.adoptium.net/artifactory/api/gpg/key/public | sudo tee /etc/apt/keyrings/adoptium.asc >/dev/null
@@ -67,7 +155,14 @@ else
                     sudo apt update -qq
                     sudo apt install -y temurin-17-jdk
                 }
-                ok "Java 17 installed"
+                JAVA_EXE="$(find_java17)"
+                if [[ -n "$JAVA_EXE" ]]; then
+                    export JAVA_HOME="$(dirname "$(dirname "$JAVA_EXE")")"
+                    export PATH="$(dirname "$JAVA_EXE"):$PATH"
+                    ok "Java 17 installed: $JAVA_EXE"
+                else
+                    ok "Java 17 installed (restart terminal if PATH not updated)"
+                fi
             else
                 info "Manual install: https://adoptium.net/"
                 exit 1
@@ -89,7 +184,14 @@ else
             if ask_yn "Auto-install via Homebrew?"; then
                 build "brew install --cask temurin@17 ..."
                 brew install --cask temurin@17
-                ok "Java 17 installed"
+                JAVA_EXE="$(find_java17)"
+                if [[ -n "$JAVA_EXE" ]]; then
+                    export JAVA_HOME="$(dirname "$(dirname "$JAVA_EXE")")"
+                    export PATH="$(dirname "$JAVA_EXE"):$PATH"
+                    ok "Java 17 installed: $JAVA_EXE"
+                else
+                    ok "Java 17 installed (restart terminal if PATH not updated)"
+                fi
             else
                 info "Manual: brew install --cask temurin@17"
                 exit 1


### PR DESCRIPTION
…allers

Previously only checked `java` in PATH. Now searches 7-9 sources per OS:

PowerShell (.ps1):
  Find-Java17 helper checks PATH → JAVA_HOME → registry (JavaSoft/WOW6432Node)
  → vendor dirs under Program Files (Adoptium, Microsoft, Corretto, BellSoft,
    Zulu, OpenLogic, SapMachine, GraalVM) → direct glob → Minecraft bundled
  JRE → SDKMan. Sets JAVA_HOME + prepends bin dir to PATH for this session.

Bash (.sh):
  find_java17() checks PATH → JAVA_HOME → update-alternatives → /usr/lib/jvm/*
  → macOS /Library/Java/JavaVirtualMachines → Homebrew (Intel + Apple Silicon)
  → SDKMan → ASDF → Minecraft launcher bundled JRE. Exports JAVA_HOME + PATH.

Batch (.bat):
  Added setlocal EnableDelayedExpansion + fallback search through JAVA_HOME
  and vendor subdirs under Program Files with delayed expansion errorlevel.

All three: after successful detection, java is added to front of PATH so Gradle and the Forge installer inherit the correct JDK automatically.

https://claude.ai/code/session_01YDGyLr1Rm6BYPodVocRzWf