### PR TITLE
fix(installer): prevent window from closing immediately on open

### DIFF
--- a/install/quick-install.bat
+++ b/install/quick-install.bat
@@ -8,6 +8,11 @@ chcp 65001 >nul 2>&1
 where powershell >nul 2>&1
 if %errorLevel% equ 0 (
     powershell -ExecutionPolicy Bypass -File "%~dp0quick-install.ps1"
+    if %errorLevel% neq 0 (
+        echo.
+        echo [X] Installer exited with error code %errorLevel%
+        pause
+    )
     exit /b %errorLevel%
 )
 

--- a/install/quick-install.ps1
+++ b/install/quick-install.ps1
@@ -7,8 +7,20 @@
     Supports auto-download, auto-build from source, multi-path JAR scanning.
 #>
 
-$ErrorActionPreference = 'Stop'
+# Use Continue so non-fatal errors don't terminate the script silently.
+# Individual critical sections use their own try/catch.
+$ErrorActionPreference = 'Continue'
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+# Wrap everything so Read-Host is ALWAYS reached — prevents window from
+# closing immediately when an unhandled exception occurs.
+trap {
+    Write-Host ''
+    Write-Host "  [X] Unexpected error: $_" -ForegroundColor Red
+    Write-Host '      Please report this at https://github.com/rocky59487/Block-Realityapi-Fast-design/issues' -ForegroundColor Yellow
+    Read-Host 'Press Enter to close'
+    exit 1
+}
 
 # ============================================================
 #  Configuration
@@ -421,3 +433,4 @@ Write-Host '    /br toggle       - Enable/disable physics' -ForegroundColor Gray
 Write-Host '    /br vulkan_test  - Test Vulkan support'    -ForegroundColor Gray
 Write-Host ''
 Read-Host 'Press Enter to close'
+exit 0


### PR DESCRIPTION
PowerShell (.ps1):
  - Changed ErrorActionPreference Stop → Continue; critical sections already have their own try/catch, so Stop was causing silent exit on minor errors
  - Added trap {} handler: catches any unhandled exception, prints the error, then calls Read-Host so the window stays open long enough to read the msg
  - Added explicit exit 0 at end to ensure clean exit code

Batch (.bat):
  - Added error-code check after PowerShell returns: if PS exited non-zero (e.g. got killed before Read-Host ran), prints the error code and pauses so the CMD window doesn't silently disappear

