### PR TITLE
fix(installer): replace PS7-only ?. operator with PS5.1-compatible sy…

### DIFF
--- a/install/quick-install.ps1
+++ b/install/quick-install.ps1
@@ -74,8 +74,9 @@ function Find-Java17 {
         } catch { return $false }
     }
 
-    # 1. PATH / default
-    $pathJava = (Get-Command java -ErrorAction SilentlyContinue)?.Source
+    # 1. PATH / default  (PS 5.1-compatible — avoid ?. null-conditional)
+    $pathJavaCmd = Get-Command java -ErrorAction SilentlyContinue
+    $pathJava = if ($pathJavaCmd) { $pathJavaCmd.Source } else { $null }
     if ($pathJava -and (Test-Java17 $pathJava)) { return $pathJava }
 
     # 2. JAVA_HOME env var


### PR DESCRIPTION
…ntax

?.Source (null-conditional member access) is PowerShell 7+ syntax. Windows 10/11 ships with PS 5.1 by default. When PS 5.1 tries to parse this operator it throws a parse error BEFORE any code runs — before trap{}, before ErrorActionPreference, before anything — so the window closes instantly with no output.

Fix: replaced with explicit null check compatible with PS 5.1:
  $cmd = Get-Command java -ErrorAction SilentlyContinue
  $path = if ($cmd) { $cmd.Source } else { $null }

