### PR TITLE
Fix quick-install.ps1 PowerShell 5.1 Compatibility

### DIFF
--- a/install/quick-install.ps1
+++ b/install/quick-install.ps1
@@ -76,7 +76,7 @@ function Find-Java17 {
 
     # 1. PATH / default  (PS 5.1-compatible — avoid ?. null-conditional)
     $pathJavaCmd = Get-Command java -ErrorAction SilentlyContinue
-    $pathJava = if ($pathJavaCmd) { $pathJavaCmd.Source } else { $null }
+    if ($pathJavaCmd) { $pathJava = $pathJavaCmd.Source } else { $pathJava = $null }
     if ($pathJava -and (Test-Java17 $pathJava)) { return $pathJava }
 
     # 2. JAVA_HOME env var


### PR DESCRIPTION
Fix syntax error in quick-install.ps1 for PowerShell 5.1 compatibility

---
*PR created automatically by Jules for task [8766730574959384905](https://jules.google.com/task/8766730574959384905) started by @rocky59487*