### PR TITLE
[MODS] Lower blockreality dependency version requirement to 0.2a

### DIFF
--- a/Block Reality/fastdesign/src/main/resources/META-INF/mods.toml
+++ b/Block Reality/fastdesign/src/main/resources/META-INF/mods.toml
@@ -25,6 +25,6 @@ description     = '''三視角 CAD 建築設計模組 — 基於 Block Reality A
 [[dependencies.fastdesign]]
     modId      = "blockreality"
     mandatory  = true
-    versionRange = "[1.0.0,)"
+    versionRange = "[0.2a,)"
     ordering   = "AFTER"
     side       = "BOTH"

--- a/Block Reality/merged-resources/META-INF/mods.toml
+++ b/Block Reality/merged-resources/META-INF/mods.toml
@@ -49,6 +49,6 @@ description     = '''三視角 CAD 建築設計模組 — 基於 Block Reality A
 [[dependencies.fastdesign]]
     modId      = "blockreality"
     mandatory  = true
-    versionRange = "[1.0.0,)"
+    versionRange = "[0.2a,)"
     ordering   = "AFTER"
     side       = "BOTH"


### PR DESCRIPTION
Lowered the required version range of the `blockreality` dependency for `fastdesign` from `[1.0.0,)` to `[0.2a,)` in `META-INF/mods.toml` files to fix dependency mismatch issues.

---
*PR created automatically by Jules for task [6495497018685646071](https://jules.google.com/task/6495497018685646071) started by @rocky59487*