### PR TITLE
feat: full material coverage in ML training — 12 materials + Rtens

### DIFF
--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/OnnxPFSFRuntime.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/OnnxPFSFRuntime.java
@@ -34,6 +34,7 @@ public class OnnxPFSFRuntime {
     private static final float E_SCALE   = 200e9f;
     private static final float RHO_SCALE = 7850.0f;
     private static final float RC_SCALE  = 250.0f;
+    private static final float RT_SCALE  = 500.0f;    // steel Rtens
 
     private OrtEnvironment env;
     private OrtSession session;
@@ -76,7 +77,7 @@ public class OnnxPFSFRuntime {
                 NodeInfo firstInput = inputs.values().iterator().next();
                 if (firstInput.getInfo() instanceof TensorInfo ti) {
                     long[] shape = ti.getShape();
-                    if (shape.length == 5 && shape[4] == 5) {
+                    if (shape.length == 5 && (shape[4] == 5 || shape[4] == 6)) {
                         gridSize = (int) shape[1];
                     }
                 }
@@ -133,7 +134,7 @@ public class OnnxPFSFRuntime {
         try {
             // ── Build input tensor [1, L, L, L, 5] in row-major order ──
             // Index: batch*L*L*L*5 + x*L*L*5 + y*L*5 + z*5 + channel
-            float[] input = new float[1 * L * L * L * 5];
+            float[] input = new float[1 * L * L * L * 6];
 
             for (BlockPos pos : members) {
                 int ix = pos.getX() - minX;
@@ -143,19 +144,18 @@ public class OnnxPFSFRuntime {
                 RMaterial mat = materialLookup.apply(pos);
                 if (mat == null) continue;
 
-                boolean isAnchor = anchorLookup != null && anchorLookup.apply(pos);
-                int base = ((ix * L + iy) * L + iz) * 5;
+                int base = ((ix * L + iy) * L + iz) * 6;
 
-                // Channel 0: occupancy (must match Python training: 1.0=solid, 0.0=air)
-                // Anchors and solids both = 1.0 in training data (occupancy is binary)
-                input[base]     = 1.0f;
-                input[base + 1] = (float)(mat.getYoungsModulusPa() / E_SCALE);
-                input[base + 2] = (float) mat.getPoissonsRatio();
-                input[base + 3] = (float)(mat.getDensity() / RHO_SCALE);
-                input[base + 4] = (float)(mat.getRcomp() / RC_SCALE);
+                // 6ch — must match Python training normalization
+                input[base]     = 1.0f;                                          // occupancy
+                input[base + 1] = (float)(mat.getYoungsModulusPa() / E_SCALE);  // E
+                input[base + 2] = (float) mat.getPoissonsRatio();                // nu
+                input[base + 3] = (float)(mat.getDensity() / RHO_SCALE);         // density
+                input[base + 4] = (float)(mat.getRcomp() / RC_SCALE);            // Rcomp
+                input[base + 5] = (float)(mat.getRtens() / RT_SCALE);            // Rtens
             }
 
-            long[] shape = {1, L, L, L, 5};
+            long[] shape = {1, L, L, L, 6};
             OnnxTensor inputTensor = OnnxTensor.createTensor(env, FloatBuffer.wrap(input), shape);
 
             // ── Run inference ──

--- a/brml/brml/export/onnx_contracts.py
+++ b/brml/brml/export/onnx_contracts.py
@@ -37,8 +37,8 @@ SURROGATE = ModelContract(
     model_id="bifrost_surrogate",
     version=1,
     inputs=[
-        TensorSpec("input", (1, -1, -1, -1, 5), "float32",
-                   "occ(1) + E_norm(1) + nu(1) + rho_norm(1) + rcomp_norm(1)"),
+        TensorSpec("input", (1, -1, -1, -1, 6), "float32",
+                   "occ(1) + E_norm(1) + nu(1) + rho_norm(1) + rcomp_norm(1) + rtens_norm(1)"),
     ],
     outputs=[
         TensorSpec("output", (1, -1, -1, -1, 10), "float32",

--- a/brml/brml/models/unified.py
+++ b/brml/brml/models/unified.py
@@ -67,7 +67,7 @@ class FNOBlock(nn.Module):
 class PFSFSurrogate(nn.Module):
     """PFSF-native surrogate — predicts converged φ from geometry.
 
-    Input channels (5): occupancy, E_norm, nu, density_norm, rcomp_norm
+    Input channels (6): occupancy, E_norm, nu, density_norm, rcomp_norm, rtens_norm
     Output: 1-channel φ field (directly compatible with failure_scan)
     """
 

--- a/brml/brml/pipeline/auto_train.py
+++ b/brml/brml/pipeline/auto_train.py
@@ -37,13 +37,21 @@ def _import_jax():
 #  Stage 1: Structure Generator
 # ═══════════════════════════════════════════════════════════════
 
-# Material presets mirroring DefaultMaterial.java
+# Material presets — full 12 materials mirroring DefaultMaterial.java
+# Includes Rtens for tension failure detection
 MATERIALS = {
-    "concrete":  {"E_pa": 30e9,  "nu": 0.20, "density": 2400.0, "rcomp": 30.0},
-    "steel":     {"E_pa": 200e9, "nu": 0.30, "density": 7850.0, "rcomp": 250.0},
-    "timber":    {"E_pa": 12e9,  "nu": 0.35, "density": 500.0,  "rcomp": 30.0},
-    "brick":     {"E_pa": 15e9,  "nu": 0.15, "density": 1800.0, "rcomp": 15.0},
-    "stone":     {"E_pa": 40e9,  "nu": 0.25, "density": 2600.0, "rcomp": 50.0},
+    "plain_concrete": {"E_pa": 25e9,  "nu": 0.18, "density": 2400.0, "rcomp": 25.0,  "rtens": 2.5},
+    "rebar":          {"E_pa": 200e9, "nu": 0.29, "density": 7850.0, "rcomp": 250.0, "rtens": 400.0},
+    "concrete":       {"E_pa": 30e9,  "nu": 0.20, "density": 2350.0, "rcomp": 30.0,  "rtens": 3.0},
+    "rc_node":        {"E_pa": 32e9,  "nu": 0.20, "density": 2500.0, "rcomp": 33.0,  "rtens": 5.9},
+    "brick":          {"E_pa": 5e9,   "nu": 0.15, "density": 1800.0, "rcomp": 10.0,  "rtens": 0.5},
+    "timber":         {"E_pa": 11e9,  "nu": 0.35, "density": 600.0,  "rcomp": 5.0,   "rtens": 8.0},
+    "steel":          {"E_pa": 200e9, "nu": 0.29, "density": 7850.0, "rcomp": 350.0, "rtens": 500.0},
+    "stone":          {"E_pa": 50e9,  "nu": 0.25, "density": 2400.0, "rcomp": 30.0,  "rtens": 3.0},
+    "glass":          {"E_pa": 70e9,  "nu": 0.22, "density": 2500.0, "rcomp": 100.0, "rtens": 30.0},
+    "sand":           {"E_pa": 0.01e9,"nu": 0.30, "density": 1600.0, "rcomp": 0.1,   "rtens": 0.0},
+    "obsidian":       {"E_pa": 70e9,  "nu": 0.20, "density": 2600.0, "rcomp": 200.0, "rtens": 5.0},
+    "bedrock":        {"E_pa": 1e12,  "nu": 0.10, "density": 3000.0, "rcomp": 1e6,   "rtens": 1e6},
 }
 MAT_NAMES = list(MATERIALS.keys())
 
@@ -57,6 +65,7 @@ class VoxelStructure:
     nu_field: np.ndarray    # float64 [Lx, Ly, Lz]
     density_field: np.ndarray  # float64 [Lx, Ly, Lz]
     rcomp_field: np.ndarray    # float64 [Lx, Ly, Lz]
+    rtens_field: np.ndarray    # float64 [Lx, Ly, Lz] — tension strength (MPa)
     mat_ids: np.ndarray     # int [Lx, Ly, Lz] — material index
 
 
@@ -224,6 +233,7 @@ def generate_structure(L: int, rng: np.random.Generator,
     nu_field = np.zeros((L, L, L), dtype=np.float64)
     density_field = np.zeros((L, L, L), dtype=np.float64)
     rcomp_field = np.zeros((L, L, L), dtype=np.float64)
+    rtens_field = np.zeros((L, L, L), dtype=np.float64)
 
     for i, name in enumerate(MAT_NAMES):
         m = MATERIALS[name]
@@ -232,12 +242,13 @@ def generate_structure(L: int, rng: np.random.Generator,
         nu_field[mask] = m["nu"]
         density_field[mask] = m["density"]
         rcomp_field[mask] = m["rcomp"]
+        rtens_field[mask] = m["rtens"]
 
     return VoxelStructure(
         occupancy=occ, anchors=anchors,
         E_field=E_field, nu_field=nu_field,
         density_field=density_field, rcomp_field=rcomp_field,
-        mat_ids=mat_idx,
+        rtens_field=rtens_field, mat_ids=mat_idx,
     )
 
 

--- a/brml/brml/pipeline/concurrent_trainer.py
+++ b/brml/brml/pipeline/concurrent_trainer.py
@@ -26,7 +26,7 @@ import numpy as np
 @dataclass
 class Sample:
     """Single training sample: input features + target φ."""
-    input_5ch: np.ndarray   # [L, L, L, 5] — occ, E, nu, rho, rcomp (normalized)
+    input_6ch: np.ndarray   # [L, L, L, 6] — occ, E, nu, rho, rcomp, rtens (normalized)
     target: np.ndarray       # [L, L, L]   — converged φ (PFSF) or vm (FEM)
     mask: np.ndarray         # [L, L, L]   — occupancy mask
     model_type: str          # "surrogate" | "fluid" | "collapse"
@@ -158,13 +158,14 @@ class ConcurrentPipeline:
                 if not fem.converged:
                     continue
 
-                # Build 5ch input (matches Java OnnxPFSFRuntime normalization)
+                # Build 6ch input (matches Java OnnxPFSFRuntime normalization)
                 occ = struct.occupancy.astype(np.float32)
                 E_n = struct.E_field.astype(np.float32) / 200e9
                 nu = struct.nu_field.astype(np.float32)
                 rho_n = struct.density_field.astype(np.float32) / 7850.0
                 rc_n = struct.rcomp_field.astype(np.float32) / 250.0
-                inp = np.stack([occ, E_n, nu, rho_n, rc_n], axis=-1)
+                rt_n = struct.rtens_field.astype(np.float32) / 500.0  # steel rtens
+                inp = np.stack([occ, E_n, nu, rho_n, rc_n, rt_n], axis=-1)
 
                 self._queue.put(Sample(
                     input_5ch=inp,
@@ -205,7 +206,7 @@ class ConcurrentPipeline:
         model = PFSFSurrogate(hidden=cfg.hidden, layers=cfg.layers, modes=cfg.modes)
 
         rng = jax.random.PRNGKey(cfg.seed)
-        variables = model.init(rng, jnp.zeros((1, L, L, L, 5)))
+        variables = model.init(rng, jnp.zeros((1, L, L, L, 6)))
         opt = optax.chain(
             optax.clip_by_global_norm(1.0),
             optax.adamw(learning_rate=cfg.learning_rate, weight_decay=1e-4),

--- a/brml/tests/test_onnx_contracts.py
+++ b/brml/tests/test_onnx_contracts.py
@@ -10,7 +10,7 @@ def test_surrogate_contract():
     # Java OnnxPFSFRuntime expects these exact shapes
     L = 12
     errors = validate_contract("surrogate",
-                               {"input": (1, L, L, L, 5)},
+                               {"input": (1, L, L, L, 6)},
                                {"output": (1, L, L, L, 10)})
     assert errors == [], f"Contract violations: {errors}"
 


### PR DESCRIPTION
Was: 5 materials (concrete, steel, timber, brick, stone), no Rtens Now: 12 materials matching DefaultMaterial.java exactly:
  plain_concrete, rebar, concrete, rc_node, brick, timber, steel,
  stone, glass, sand, obsidian, bedrock — all with Rtens values

Input channels: 5ch → 6ch (added Rtens / 500.0 normalization)
  ch0: occupancy    ch1: E/200e9    ch2: nu
  ch3: rho/7850     ch4: Rcomp/250  ch5: Rtens/500 (NEW)

Updated across entire stack:
  - auto_train.py: MATERIALS dict (12 entries), VoxelStructure.rtens_field
  - concurrent_trainer.py: 6ch input construction
  - unified.py: PFSFSurrogate docstring
  - OnnxPFSFRuntime.java: 6ch input + RT_SCALE + mat.getRtens()
  - onnx_contracts.py: surrogate input shape (1,-1,-1,-1,6)
  - test: updated contract test to 6ch