### PR TITLE
Fix CI Build Compilation Errors

### DIFF
--- a/Block Reality/api/src/main/java/com/blockreality/api/client/render/rt/BRVulkanBVH.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/client/render/rt/BRVulkanBVH.java
@@ -338,8 +338,8 @@ public final class BRVulkanBVH {
                 .flags(VK_GEOMETRY_OPAQUE_BIT_KHR);
             geometry.get(0).geometry().aabbs()
                 .sType(VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_AABBS_DATA_KHR)
-                .data().deviceAddress(aabbDeviceAddress)
                 .stride(6 * Float.BYTES);
+            geometry.get(0).geometry().aabbs().data().deviceAddress(aabbDeviceAddress);
 
             // 2. Build geometry info
             VkAccelerationStructureBuildGeometryInfoKHR buildInfo =
@@ -392,13 +392,14 @@ public final class BRVulkanBVH {
             rangeInfo.get(0).primitiveCount(aabbCount).primitiveOffset(0)
                 .firstVertex(0).transformOffset(0);
 
-            VkCommandBuffer cmdBuf = BRVulkanDevice.beginSingleTimeCommands(device);
+            long cmdBufHandle = BRVulkanDevice.beginSingleTimeCommands(device);
+            VkCommandBuffer cmdBuf = new VkCommandBuffer(cmdBufHandle, BRVulkanDevice.getVkDeviceObj());
             // vkCmdBuildAccelerationStructuresKHR needs Buffer + PointerBuffer
             VkAccelerationStructureBuildGeometryInfoKHR.Buffer buildInfoBuf =
                 VkAccelerationStructureBuildGeometryInfoKHR.create(buildInfo.address(), 1);
             KHRAccelerationStructure.vkCmdBuildAccelerationStructuresKHR(
                 cmdBuf, buildInfoBuf, stack.pointers(rangeInfo));
-            BRVulkanDevice.endSingleTimeCommands(device, cmdBuf);
+            BRVulkanDevice.endSingleTimeCommands(device, cmdBufHandle);
 
             // 6. Store in blasMap (handle is valid → safe to use in RT pipeline)
             SectionBLAS blas = new SectionBLAS();
@@ -625,8 +626,8 @@ public final class BRVulkanBVH {
                 .flags(VK_GEOMETRY_OPAQUE_BIT_KHR);
             tlasGeometry.get(0).geometry().instances()
                 .sType(VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_INSTANCES_DATA_KHR)
-                .data().deviceAddress(BRVulkanDevice.getBufferDeviceAddress(device, instanceBuffer))
                 .arrayOfPointers(false);
+            tlasGeometry.get(0).geometry().instances().data().deviceAddress(BRVulkanDevice.getBufferDeviceAddress(device, instanceBuffer));
 
             VkAccelerationStructureBuildGeometryInfoKHR tlasBuildInfo =
                 VkAccelerationStructureBuildGeometryInfoKHR.calloc(stack);
@@ -652,13 +653,14 @@ public final class BRVulkanBVH {
                 .firstVertex(0)
                 .transformOffset(0);
 
-            VkCommandBuffer tlasCmdBuf = BRVulkanDevice.beginSingleTimeCommands(device);
+            long tlasCmdBufHandle = BRVulkanDevice.beginSingleTimeCommands(device);
+            VkCommandBuffer tlasCmdBuf = new VkCommandBuffer(tlasCmdBufHandle, BRVulkanDevice.getVkDeviceObj());
             // vkCmdBuildAccelerationStructuresKHR needs Buffer + PointerBuffer
             VkAccelerationStructureBuildGeometryInfoKHR.Buffer tlasBuildInfoBuf =
                 VkAccelerationStructureBuildGeometryInfoKHR.create(tlasBuildInfo.address(), 1);
             KHRAccelerationStructure.vkCmdBuildAccelerationStructuresKHR(
                 tlasCmdBuf, tlasBuildInfoBuf, stack.pointers(tlasRangeInfo));
-            BRVulkanDevice.endSingleTimeCommands(device, tlasCmdBuf);
+            BRVulkanDevice.endSingleTimeCommands(device, tlasCmdBufHandle);
 
             LOGGER.debug("[BVH] TLAS {}: {} instances", useUpdateMode ? "updated" : "built", instanceCount);
 


### PR DESCRIPTION
Fixed the issues in `BRVulkanBVH.java` to make it compile successfully against LWJGL 3.3.1. These compile errors were breaking the CI pipeline.

---
*PR created automatically by Jules for task [17529490682634305596](https://jules.google.com/task/17529490682634305596) started by @rocky59487*