### PR TITLE
fix(P0/P1): resolve ML bypass, GPU garbage data, RT trigger, and node…

### DIFF
--- a/Block Reality/api/src/main/java/com/blockreality/api/client/rendering/bridge/ForgeRenderEventBridge.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/client/rendering/bridge/ForgeRenderEventBridge.java
@@ -1,5 +1,6 @@
 package com.blockreality.api.client.rendering.bridge;
 
+import com.blockreality.api.client.rendering.BRRTCompositor;
 import com.blockreality.api.client.rendering.lod.BRVoxelLODManager;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
@@ -57,6 +58,11 @@ public final class ForgeRenderEventBridge {
         if (stage == RenderLevelStageEvent.Stage.AFTER_SOLID_BLOCKS) {
             // 渲染 LOD 不透明地形
             renderLODOpaque(event);
+        }
+
+        if (stage == RenderLevelStageEvent.Stage.AFTER_TRANSLUCENT_BLOCKS) {
+            // 所有不透明+半透明幾何已入 GBuffer — 執行 Vulkan RT 合成
+            renderRTComposite(event);
         }
     }
 
@@ -122,6 +128,17 @@ public final class ForgeRenderEventBridge {
             BRVoxelLODManager.getInstance().renderOpaque();
         } catch (Exception e) {
             LOG.error("LOD renderOpaque error", e);
+        }
+    }
+
+    private static void renderRTComposite(RenderLevelStageEvent event) {
+        try {
+            PoseStack poseStack = event.getPoseStack();
+            Matrix4f proj = new Matrix4f(RenderSystem.getProjectionMatrix());
+            Matrix4f view = new Matrix4f(poseStack.last().pose());
+            BRRTCompositor.getInstance().executeRTPass(proj, view);
+        } catch (Exception e) {
+            LOG.error("RT composite error", e);
         }
     }
 

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/BIFROSTModelRegistry.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/BIFROSTModelRegistry.java
@@ -44,7 +44,7 @@ public final class BIFROSTModelRegistry {
 
     /** Known model contract IDs and their expected output channel counts. */
     private static final Map<String, ModelSpec> SPECS = Map.of(
-        "bifrost_surrogate", new ModelSpec(5, 10, "structural physics"),
+        "bifrost_surrogate", new ModelSpec(6, 10, "structural physics"),
         "bifrost_fluid",     new ModelSpec(8, 4, "water simulation"),
         "bifrost_lod",       new ModelSpec(14, 4, "chunk LOD tier"),
         "bifrost_collapse",  new ModelSpec(8, 5, "collapse prediction")

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/HybridPhysicsRouter.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/HybridPhysicsRouter.java
@@ -85,6 +85,24 @@ public class HybridPhysicsRouter {
         }
     }
 
+    /**
+     * Initialize router with a pre-loaded OnnxPFSFRuntime (from BIFROSTModelRegistry).
+     * Avoids double-loading the model from disk. Named distinctly to prevent ambiguity
+     * with the path-based {@link #init(String)} overload when passing null.
+     *
+     * @param runtime already-loaded ONNX runtime (null = FNO disabled)
+     */
+    public void initWithRuntime(OnnxPFSFRuntime runtime) {
+        if (runtime != null && runtime.isReady()) {
+            this.onnxRuntime = runtime;
+            this.fnoAvailable = true;
+            LOGGER.info("[Router] FNO runtime injected (grid={}), hybrid routing enabled",
+                    runtime.getGridSize());
+        } else {
+            LOGGER.info("[Router] No FNO runtime provided, all islands → PFSF");
+        }
+    }
+
     /** Get the ONNX runtime (null if not available). */
     public OnnxPFSFRuntime getOnnxRuntime() { return onnxRuntime; }
 

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFBufferManager.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFBufferManager.java
@@ -90,6 +90,9 @@ public final class PFSFBufferManager {
             buf.release();
             return prev;
         }
+        // Force a full data upload on the first solve — GPU has no data yet for this island.
+        PFSFSparseUpdate sparse = sparseTrackers.computeIfAbsent(island.getId(), PFSFSparseUpdate::new);
+        sparse.markFullRebuild();
         return buf;
     }
 

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFEngine.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFEngine.java
@@ -50,10 +50,11 @@ public final class PFSFEngine {
         // BIFROST: load all ML models from config/blockreality/models/
         modelRegistry.init();
 
-        // BIFROST: initialize hybrid router with surrogate model
+        // BIFROST: initialize hybrid router with the already-loaded surrogate runtime.
+        // Use initWithRuntime() to inject the pre-loaded OnnxPFSFRuntime directly,
+        // avoiding re-reading from disk and the previous "loaded" literal bug.
         OnnxPFSFRuntime surrogate = modelRegistry.getSurrogate();
-        String modelPath = surrogate != null ? "loaded" : null;
-        router.init(modelPath);
+        router.initWithRuntime(surrogate);
     }
 
     public static void shutdown() {

--- a/Block Reality/fastdesign/src/main/java/com/blockreality/fastdesign/FastDesignMod.java
+++ b/Block Reality/fastdesign/src/main/java/com/blockreality/fastdesign/FastDesignMod.java
@@ -19,6 +19,7 @@ import net.minecraftforge.fml.DistExecutor;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
+import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
 import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
 import org.apache.logging.log4j.LogManager;
@@ -47,6 +48,7 @@ public class FastDesignMod {
         ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, FastDesignConfig.COMMON_SPEC);
 
         modBus.addListener(this::commonSetup);
+        modBus.addListener(this::clientSetup);
 
         MinecraftForge.EVENT_BUS.register(this);
 
@@ -82,6 +84,40 @@ public class FastDesignMod {
             == net.minecraftforge.api.distmarker.Dist.CLIENT;
         StartupScanPipeline.getInstance().start(isClient);
         LOGGER.info("[FastDesign] Startup scan pipeline launched");
+    }
+
+    /**
+     * Client-only setup — registers node types, presets, and binders early
+     * so they are available before any UI screen opens.
+     *
+     * P1-6: NodeRegistry.registerAll() moved here from NodeCanvasScreen.init()
+     * P1-5: NodeGraphIO presets registered so BRRenderSettings.init() doesn't get null graphs
+     */
+    private void clientSetup(FMLClientSetupEvent event) {
+        event.enqueueWork(() -> {
+            // P1-6: Register all 149 node types at mod load time (not at UI-open time).
+            //        NodeRegistry.registerAll() has an internal guard so double-calls are safe.
+            com.blockreality.fastdesign.client.node.NodeRegistry.registerAll();
+            LOGGER.info("[FastDesign] NodeRegistry: {} types registered",
+                    com.blockreality.fastdesign.client.node.NodeRegistry.registeredCount());
+
+            // P1-5: Register quality-preset factories in the API-layer NodeGraphIO.
+            //        BRRenderSettings.createPresetGraph() calls NodeGraphIO.loadPreset(),
+            //        which previously returned null because nothing was registered.
+            //        We register minimal (empty) graphs here; real preset wiring can
+            //        be added incrementally via NodeGraphIO.registerNodeType() factories.
+            com.blockreality.api.node.NodeGraphIO.registerPreset("potato",
+                    () -> new com.blockreality.api.node.NodeGraph("preset_potato"));
+            com.blockreality.api.node.NodeGraphIO.registerPreset("low",
+                    () -> new com.blockreality.api.node.NodeGraph("preset_low"));
+            com.blockreality.api.node.NodeGraphIO.registerPreset("medium",
+                    () -> new com.blockreality.api.node.NodeGraph("preset_medium"));
+            com.blockreality.api.node.NodeGraphIO.registerPreset("high",
+                    () -> new com.blockreality.api.node.NodeGraph("preset_high"));
+            com.blockreality.api.node.NodeGraphIO.registerPreset("ultra",
+                    () -> new com.blockreality.api.node.NodeGraph("preset_ultra"));
+            LOGGER.info("[FastDesign] NodeGraphIO: 5 quality presets registered");
+        });
     }
 
     @SubscribeEvent

--- a/Block Reality/fastdesign/src/main/java/com/blockreality/fastdesign/client/node/binding/LivePreviewBridge.java
+++ b/Block Reality/fastdesign/src/main/java/com/blockreality/fastdesign/client/node/binding/LivePreviewBridge.java
@@ -1,5 +1,6 @@
 package com.blockreality.fastdesign.client.node.binding;
 
+import com.blockreality.api.client.render.BRRenderSettings;
 import com.blockreality.api.config.BRConfig;
 import com.blockreality.fastdesign.client.node.NodeGraph;
 import com.blockreality.fastdesign.config.FastDesignConfig;
@@ -137,6 +138,15 @@ public class LivePreviewBridge {
         // FastDesign 配置
         if (fdConfigBinder != null) {
             fdConfigBinder.apply(null); // FastDesignConfig 使用 static fields
+        }
+
+        // P1-7: 同步 MutableRenderConfig 覆蓋值至 API 層 BRRenderSettings，
+        //        確保 ForgeRenderEventBridge（RT/LOD 開關）讀取正確狀態。
+        if (BRRenderSettings.isInitialized() && renderConfig.isOverrideActive()) {
+            BRRenderSettings.setEffect("ssao", renderConfig.ssaoEnabled);
+            BRRenderSettings.setEffect("taa", renderConfig.taaEnabled);
+            BRRenderSettings.setEffect("rt_gi", renderConfig.rtGIEnabled);
+            BRRenderSettings.setShadowResolution(renderConfig.shadowMapResolution);
         }
     }
 


### PR DESCRIPTION
… init bugs

P0-1 PFSFBufferManager: call sparse.markFullRebuild() after creating a new island buffer so the GPU receives a full data upload on the first solve tick instead of processing uninitialised memory.

P0-2 HybridPhysicsRouter/PFSFEngine: replace the \"loaded\" string literal bug. Added HybridPhysicsRouter.initWithRuntime(OnnxPFSFRuntime) so the router accepts an already-loaded runtime from BIFROSTModelRegistry without re-reading disk. PFSFEngine.init() now calls router.initWithRuntime(surrogate), enabling FNO inference whenever a model file is present.

P0-3 BIFROSTModelRegistry: fix bifrost_surrogate input channels 5→6 to match OnnxPFSFRuntime's expected layout (occ, E, ν, ρ, Rcomp, Rtens).

P0-4 ForgeRenderEventBridge: add AFTER_TRANSLUCENT_BLOCKS subscription that calls BRRTCompositor.executeRTPass(), wiring the Vulkan RT compositor into the render loop as its Javadoc specifies.

P1-5 FastDesignMod.clientSetup: register 5 quality preset factories in the API NodeGraphIO so BRRenderSettings.createPresetGraph() no longer returns null.

P1-6 FastDesignMod.clientSetup: call NodeRegistry.registerAll() at mod load time rather than waiting for NodeCanvasScreen.init(), ensuring node types are available before any serialisation or preset loading occurs.

P1-7 LivePreviewBridge.applyAll(): sync SSAO, TAA, shadow resolution, and RT GI toggles from MutableRenderConfig to BRRenderSettings so the API render layer reflects node-graph-driven overrides.

