### PR TITLE
fix(pfsf): PFSF-1~5 deep-search audit fixes

### DIFF
--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFDispatcher.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFDispatcher.java
@@ -200,7 +200,7 @@ public final class PFSFDispatcher {
             VulkanComputeContext.bindBufferToDescriptor(ds, 2, buf.getDFieldBuf(),       0, buf.getDFieldSize());
             VulkanComputeContext.bindBufferToDescriptor(ds, 3, buf.getConductivityBuf(), buf.getConductivityOffset(), buf.getConductivitySize());
             VulkanComputeContext.bindBufferToDescriptor(ds, 4, buf.getTypeBuf(),         buf.getTypeOffset(), buf.getTypeSize());
-            VulkanComputeContext.bindBufferToDescriptor(ds, 5, buf.getFailFlagsBuf(),    buf.getFailFlagsOffset(), buf.getTypeSize());
+            VulkanComputeContext.bindBufferToDescriptor(ds, 5, buf.getFailFlagsBuf(),    buf.getFailFlagsOffset(), buf.getFailFlagsSize());
             VulkanComputeContext.bindBufferToDescriptor(ds, 6, buf.getHydrationBuf(),    0, buf.getHydrationSize());
 
             org.lwjgl.vulkan.VK10.vkCmdBindDescriptorSets(

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFEngineInstance.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFEngineInstance.java
@@ -367,10 +367,11 @@ public final class PFSFEngineInstance implements IPFSFRuntime {
         byte type = newMaterial == null ? VOXEL_AIR
                 : (anchors.contains(pos) ? VOXEL_ANCHOR : VOXEL_SOLID);
         float maxPhi = newMaterial != null ? PFSFSourceBuilder.computeMaxPhi(newMaterial) : 0.0f;
-        float rcomp = newMaterial != null ? (float) newMaterial.getRcomp() : 0.0f;
+        float rcomp  = newMaterial != null ? (float) newMaterial.getRcomp() : 0.0f;
+        float rtens  = newMaterial != null ? (float) newMaterial.getRtens()  : 0.0f;
 
         sparse.markVoxelDirty(new PFSFSparseUpdate.VoxelUpdate(
-                flatIdx, source, type, maxPhi, rcomp, new float[6]));
+                flatIdx, source, type, maxPhi, rcomp, rtens, new float[6]));
     }
 
     // ═══════════════════════════════════════════════════════════════

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFFailureApplicator.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFFailureApplicator.java
@@ -65,11 +65,12 @@ public final class PFSFFailureApplicator {
         if (failures.isEmpty()) return 0;
 
         // 觸發崩塌
-        LOGGER.debug("[PFSF] Island {} — {} failures detected (cantilever={}, crush={}, orphan={})",
+        LOGGER.debug("[PFSF] Island {} — {} failures detected (cantilever={}, crush={}, orphan={}, tension={})",
                 buf.getIslandId(), failures.size(),
                 countType(failures, FailureType.CANTILEVER_BREAK),
                 countType(failures, FailureType.CRUSHING),
-                countType(failures, FailureType.NO_SUPPORT));
+                countType(failures, FailureType.NO_SUPPORT),
+                countType(failures, FailureType.TENSION_BREAK));
 
         for (var entry : failures.entrySet()) {
             CollapseManager.triggerPFSFCollapse(level, entry.getKey(), entry.getValue());
@@ -86,12 +87,16 @@ public final class PFSFFailureApplicator {
 
     /**
      * 將 GPU fail flag → FailureType。
+     *
+     * <p>必須與 failure_scan.comp.glsl 中的常數保持一致：
+     * 1 = FAIL_CANTILEVER, 2 = FAIL_CRUSHING, 3 = FAIL_NO_SUPPORT, 4 = FAIL_TENSION</p>
      */
     private static FailureType mapFailureType(byte flag) {
         return switch (flag) {
             case FAIL_CANTILEVER -> FailureType.CANTILEVER_BREAK;
-            case FAIL_CRUSHING -> FailureType.CRUSHING;
+            case FAIL_CRUSHING   -> FailureType.CRUSHING;
             case FAIL_NO_SUPPORT -> FailureType.NO_SUPPORT;
+            case FAIL_TENSION    -> FailureType.TENSION_BREAK;
             default -> null;
         };
     }

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFFailureRecorder.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFFailureRecorder.java
@@ -82,7 +82,8 @@ public final class PFSFFailureRecorder {
             VulkanComputeContext.bindBufferToDescriptor(ds, 2, buf.getConductivityBuf(), buf.getConductivityOffset(), buf.getConductivitySize());
             VulkanComputeContext.bindBufferToDescriptor(ds, 3, buf.getTypeBuf(), buf.getTypeOffset(), buf.getTypeSize());
             VulkanComputeContext.bindBufferToDescriptor(ds, 4, buf.getMaxPhiBuf(), buf.getMaxPhiOffset(), buf.getPhiSize());
-            VulkanComputeContext.bindBufferToDescriptor(ds, 5, buf.getRcompBuf(), buf.getRcompOffset(), buf.getPhiSize());
+            VulkanComputeContext.bindBufferToDescriptor(ds, 5, buf.getRcompBuf(), buf.getRcompOffset(), buf.getRtensSize());
+            VulkanComputeContext.bindBufferToDescriptor(ds, 6, buf.getRtensBuf(), buf.getRtensOffset(), buf.getRtensSize());
 
             vkCmdBindDescriptorSets(cmdBuf, VK_PIPELINE_BIND_POINT_COMPUTE,
                     scatterPipelineLayout, 0, stack.longs(ds), null);

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFIslandBuffer.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFIslandBuffer.java
@@ -652,7 +652,11 @@ public class PFSFIslandBuffer {
     // Buffer sizes (for descriptor range)
     public long getPhiSize() { return (long) getN() * Float.BYTES; }
     public long getConductivitySize() { return (long) getN() * 6 * Float.BYTES; }
-    public long getTypeSize() { return getN(); }
+    public long getTypeSize()         { return getN(); }
+    /** Size of the rtens (float per voxel) region — same as getPhiSize(). */
+    public long getRtensSize()        { return getPhiSize(); }
+    /** Size of the failFlags (byte per voxel) region. */
+    public long getFailFlagsSize()    { return getN(); }
 
     // State
     public boolean isDirty() { return dirty; }

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFPipelineFactory.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFPipelineFactory.java
@@ -70,7 +70,8 @@ public final class PFSFPipelineFactory {
             failurePipelineLayout = VulkanComputeContext.createPipelineLayout(failureDSLayout, 16);
             failurePipeline = compilePipeline("pfsf/failure_scan.comp.glsl", "failure_scan.comp", failurePipelineLayout);
 
-            scatterDSLayout = VulkanComputeContext.createDescriptorSetLayout(6);
+            // binding 0=updates, 1=source, 2=conductivity, 3=type, 4=maxPhi, 5=rcomp, 6=rtens
+            scatterDSLayout = VulkanComputeContext.createDescriptorSetLayout(7);
             scatterPipelineLayout = VulkanComputeContext.createPipelineLayout(scatterDSLayout, 8);
             scatterPipeline = compilePipeline("pfsf/sparse_scatter.comp.glsl", "sparse_scatter.comp", scatterPipelineLayout);
 

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFSourceBuilder.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFSourceBuilder.java
@@ -237,6 +237,12 @@ public final class PFSFSourceBuilder {
             {0,1,1}, {0,1,-1}, {0,-1,1}, {0,-1,-1}   // YZ 平面邊
     };
 
+    /** 8 個角連接偏移（三軸同時斜向，26-connectivity 的角方向） */
+    private static final int[][] CORNER_OFFSETS = {
+            {1,1,1}, {1,1,-1}, {1,-1,1}, {1,-1,-1},
+            {-1,1,1}, {-1,1,-1}, {-1,-1,1}, {-1,-1,-1}
+    };
+
     /**
      * 偵測只有邊/角連接（無面連接）的方塊對，為它們注入虛擬傳導率。
      * <p>
@@ -259,8 +265,10 @@ public final class PFSFSourceBuilder {
             java.util.function.Function<BlockPos, RMaterial> materialLookup) {
 
         int injected = 0;
-        // 衰減因子：邊連接的傳導率 = 面連接的 30%（面積比 ≈ 線/面 ≈ 0.3）
+        // 衰減因子：邊連接的傳導率 = 面連接的 30%（符合 SHEAR_EDGE_PENALTY）
         float EDGE_FACTOR = 0.30f;
+        // 衰減因子：角連接的傳導率 = 面連接的 15%（符合 SHEAR_CORNER_PENALTY）
+        float CORNER_FACTOR = 0.15f;
 
         for (BlockPos pos : members) {
             for (int[] offset : EDGE_OFFSETS) {
@@ -301,6 +309,33 @@ public final class PFSFSourceBuilder {
 
                 // SoA layout: sigma[dir * N + i]
                 // 只在現有 σ 為 0 時注入（不覆蓋已有的面連接）
+                int idx = dirIdx * N + flatIdx;
+                if (conductivity[idx] == 0.0f) {
+                    conductivity[idx] = baseSigma;
+                    injected++;
+                }
+            }
+
+            // ─── 角連接（8 個角方向，SHEAR_CORNER_PENALTY = 0.15） ───
+            for (int[] offset : CORNER_OFFSETS) {
+                BlockPos diag = pos.offset(offset[0], offset[1], offset[2]);
+                if (!members.contains(diag)) continue;
+
+                RMaterial matA = materialLookup != null ? materialLookup.apply(pos) : null;
+                RMaterial matB = materialLookup != null ? materialLookup.apply(diag) : null;
+                if (matA == null || matB == null) continue;
+
+                float baseSigma = (float) Math.min(matA.getRcomp(), matB.getRcomp()) * CORNER_FACTOR;
+
+                // 角連接注入到第一個非零分量方向（X 軸優先）
+                int dirIdx = offset[0] > 0 ? DIR_POS_X : DIR_NEG_X;
+
+                int x = pos.getX() - origin.getX();
+                int y = pos.getY() - origin.getY();
+                int z = pos.getZ() - origin.getZ();
+                if (x < 0 || x >= Lx || y < 0 || y >= Ly || z < 0 || z >= Lz) continue;
+                int flatIdx = x + Lx * (y + Ly * z);
+
                 int idx = dirIdx * N + flatIdx;
                 if (conductivity[idx] == 0.0f) {
                     conductivity[idx] = baseSigma;

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFSparseUpdate.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFSparseUpdate.java
@@ -41,11 +41,13 @@ public final class PFSFSparseUpdate {
             float source,            // 新的 source 值
             byte type,               // 新的 type 值
             float maxPhi,            // 新的 maxPhi
-            float rcomp,             // 新的 Rcomp
+            float rcomp,             // 新的抗壓強度 Rcomp
+            float rtens,             // 新的抗拉強度 Rtens（sparse update 之前遺漏此欄位）
             float[] conductivity     // 6 個方向的新 σ 值
     ) {
-        /** 每筆記錄的位元組大小：index(4) + source(4) + type(1→4 aligned) + maxPhi(4) + rcomp(4) + cond×6(24) = 44 bytes */
-        public static final int BYTES = 4 + 4 + 4 + 4 + 4 + 6 * 4;  // 44 bytes per update
+        /** 每筆記錄的位元組大小：
+         *  index(4) + source(4) + type(1→4 aligned) + maxPhi(4) + rcomp(4) + rtens(4) + cond×6(24) = 48 bytes */
+        public static final int BYTES = 4 + 4 + 4 + 4 + 4 + 4 + 6 * 4;  // 48 bytes per update
 
         public void writeTo(ByteBuffer buf) {
             buf.putInt(flatIndex);
@@ -53,6 +55,7 @@ public final class PFSFSparseUpdate {
             buf.putInt(type & 0xFF);  // byte → int for GPU alignment
             buf.putFloat(maxPhi);
             buf.putFloat(rcomp);
+            buf.putFloat(rtens);
             for (int d = 0; d < 6; d++) {
                 buf.putFloat(conductivity[d]);
             }

--- a/Block Reality/api/src/main/resources/assets/blockreality/shaders/compute/pfsf/sparse_scatter.comp.glsl
+++ b/Block Reality/api/src/main/resources/assets/blockreality/shaders/compute/pfsf/sparse_scatter.comp.glsl
@@ -1,18 +1,19 @@
 #version 450
 
-// ═════════════════��════════════════════��════════════════════════
+// ══════════════════════════════════════════════════════════════
 //  PFSF Sparse Scatter — GPU 端稀疏更新散布
 //  從小型 update buffer 將變更散布到大型 source/conductivity/type 陣列
 //  避免 CPU 上傳整個陣列（185,000× 頻寬節省）
 //
-//  每筆 update = 44 bytes：
+//  每筆 update = 48 bytes（12 × 4）：
 //    [0..3]   int   flatIndex
 //    [4..7]   float source
 //    [8..11]  int   type (byte→int aligned)
 //    [12..15] float maxPhi
 //    [16..19] float rcomp
-//    [20..43] float conductivity[6]
-// ═══════════════════════════════════════════════════════════════
+//    [20..23] float rtens   ← 新增抗拉強度
+//    [24..47] float conductivity[6]
+// ══════════════════════════════════════════════════════════════
 
 layout(local_size_x = 64) in;
 
@@ -23,7 +24,7 @@ layout(push_constant) uniform PC {
 
 // 打包的更新資料（由 CPU 上傳的小型 buffer）
 layout(set = 0, binding = 0) readonly buffer Updates {
-    // 每筆 11 個 uint/float（44 bytes = 11 × 4）
+    // 每筆 12 個 uint/float（48 bytes = 12 × 4）
     uint updateData[];
 };
 
@@ -33,29 +34,32 @@ layout(set = 0, binding = 2) buffer Conductivity  { float conductivity[];  };
 layout(set = 0, binding = 3) buffer Type          { uint  vtype[];         };
 layout(set = 0, binding = 4) buffer MaxPhiBuf     { float maxPhiArr[];     };
 layout(set = 0, binding = 5) buffer RcompBuf      { float rcompArr[];      };
+layout(set = 0, binding = 6) buffer RtensBuf      { float rtensArr[];      };
 
 void main() {
     uint uid = gl_GlobalInvocationID.x;
     if (uid >= pc.updateCount) return;
 
-    // 每筆 11 個 uint（44 bytes / 4 = 11）
-    uint base = uid * 11u;
+    // 每筆 12 個 uint（48 bytes / 4 = 12）
+    uint base = uid * 12u;
 
     uint  flatIndex = updateData[base + 0u];
     float src       = uintBitsToFloat(updateData[base + 1u]);
     uint  typ       = updateData[base + 2u];
     float mPhi      = uintBitsToFloat(updateData[base + 3u]);
     float rcomp     = uintBitsToFloat(updateData[base + 4u]);
+    float rtens     = uintBitsToFloat(updateData[base + 5u]);
 
     // 散布到大型陣列
-    source[flatIndex]  = src;
-    vtype[flatIndex]   = typ;
+    source[flatIndex]    = src;
+    vtype[flatIndex]     = typ;
     maxPhiArr[flatIndex] = mPhi;
     rcompArr[flatIndex]  = rcomp;
+    rtensArr[flatIndex]  = rtens;
 
     // #7-fix: SoA layout — conductivity[d * N + flatIndex]（與 CPU 一致）
     uint N = pc.totalN;
     for (uint d = 0u; d < 6u; d++) {
-        conductivity[d * N + flatIndex] = uintBitsToFloat(updateData[base + 5u + d]);
+        conductivity[d * N + flatIndex] = uintBitsToFloat(updateData[base + 6u + d]);
     }
 }

--- a/libpfsf/CMakeLists.txt
+++ b/libpfsf/CMakeLists.txt
@@ -13,6 +13,15 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 # ── Vulkan SDK ──
 find_package(Vulkan REQUIRED)
 
+# ── Vulkan Memory Allocator (VMA) — header-only, single-file ──
+include(FetchContent)
+FetchContent_Declare(vma
+    GIT_REPOSITORY https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator.git
+    GIT_TAG        v3.1.0
+    GIT_SHALLOW    TRUE
+)
+FetchContent_MakeAvailable(vma)
+
 # ── JNI (optional, for Phase 2 NativePFSFRuntime) ──
 find_package(JNI QUIET)
 option(PFSF_BUILD_JNI "Build JNI bridge for Java integration" ${JNI_FOUND})
@@ -47,6 +56,7 @@ target_include_directories(pfsf
 
 target_link_libraries(pfsf
     PUBLIC  Vulkan::Vulkan
+    PRIVATE VulkanMemoryAllocator
 )
 
 # Platform-specific

--- a/libpfsf/src/core/vulkan_context.cpp
+++ b/libpfsf/src/core/vulkan_context.cpp
@@ -1,7 +1,12 @@
 /**
  * @file vulkan_context.cpp
- * @brief Vulkan compute context — init, shutdown, buffer ops.
+ * @brief Vulkan compute context — init, shutdown, VMA buffer ops.
  */
+
+// VMA single-header implementation — define exactly once per link unit
+#define VMA_IMPLEMENTATION
+#include <vk_mem_alloc.h>
+
 #include "vulkan_context.h"
 #include <cstring>
 #include <vector>
@@ -88,6 +93,19 @@ bool VulkanContext::init() {
         return false;
     }
 
+    // ── VMA allocator ──
+    VmaAllocatorCreateInfo vmaCI{};
+    vmaCI.physicalDevice   = physDevice_;
+    vmaCI.device           = device_;
+    vmaCI.instance         = instance_;
+    vmaCI.vulkanApiVersion = VK_API_VERSION_1_2;
+
+    if (vmaCreateAllocator(&vmaCI, &allocator_) != VK_SUCCESS) {
+        fprintf(stderr, "[libpfsf] vmaCreateAllocator failed\n");
+        shutdown();
+        return false;
+    }
+
     available_ = true;
     fprintf(stderr, "[libpfsf] Vulkan initialized: %s (VRAM: %lld MB)\n",
             deviceName_.c_str(), (long long)(deviceLocalBytes_ / (1024 * 1024)));
@@ -97,6 +115,13 @@ bool VulkanContext::init() {
 void VulkanContext::shutdown() {
     if (device_ != VK_NULL_HANDLE) {
         vkDeviceWaitIdle(device_);
+
+        // VMA must be destroyed before the logical device
+        if (allocator_ != VK_NULL_HANDLE) {
+            vmaDestroyAllocator(allocator_);
+            allocator_ = VK_NULL_HANDLE;
+        }
+        allocationMap_.clear();
 
         if (cmdPool_ != VK_NULL_HANDLE) {
             vkDestroyCommandPool(device_, cmdPool_, nullptr);
@@ -201,52 +226,65 @@ uint32_t VulkanContext::findMemoryType(uint32_t typeBits, VkMemoryPropertyFlags 
     return UINT32_MAX;
 }
 
-// ═══ Buffer operations ═══
+// ═══ Buffer operations (VMA-backed) ═══
 
 bool VulkanContext::allocBuffer(VkDeviceSize size, VkBufferUsageFlags usage,
                                 VkBuffer* outBuffer, VkDeviceMemory* outMemory) {
     VkBufferCreateInfo bufCI{};
-    bufCI.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
-    bufCI.size  = size;
-    bufCI.usage = usage;
+    bufCI.sType       = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+    bufCI.size        = size;
+    bufCI.usage       = usage;
     bufCI.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
-    if (vkCreateBuffer(device_, &bufCI, nullptr, outBuffer) != VK_SUCCESS)
-        return false;
+    // Determine memory usage: staging buffers (TRANSFER_SRC) are host-visible;
+    // storage buffers are device-local.
+    bool isStaging = (usage & VK_BUFFER_USAGE_TRANSFER_SRC_BIT) &&
+                     !(usage & VK_BUFFER_USAGE_STORAGE_BUFFER_BIT);
 
-    VkMemoryRequirements memReqs;
-    vkGetBufferMemoryRequirements(device_, *outBuffer, &memReqs);
+    VmaAllocationCreateInfo vmaAllocCI{};
+    vmaAllocCI.usage = isStaging
+        ? VMA_MEMORY_USAGE_CPU_TO_GPU   // host-visible, coherent
+        : VMA_MEMORY_USAGE_GPU_ONLY;    // device-local VRAM
 
-    VkMemoryAllocateInfo allocInfo{};
-    allocInfo.sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-    allocInfo.allocationSize  = memReqs.size;
-    allocInfo.memoryTypeIndex = findMemoryType(memReqs.memoryTypeBits,
-                                               VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
-
-    if (allocInfo.memoryTypeIndex == UINT32_MAX ||
-        vkAllocateMemory(device_, &allocInfo, nullptr, outMemory) != VK_SUCCESS) {
-        vkDestroyBuffer(device_, *outBuffer, nullptr);
+    VmaAllocation allocation;
+    VkResult res = vmaCreateBuffer(allocator_, &bufCI, &vmaAllocCI,
+                                   outBuffer, &allocation, nullptr);
+    if (res != VK_SUCCESS) {
         *outBuffer = VK_NULL_HANDLE;
+        if (outMemory) *outMemory = VK_NULL_HANDLE;
         return false;
     }
-    vkBindBufferMemory(device_, *outBuffer, *outMemory, 0);
+
+    // Track allocation for later free/map
+    allocationMap_[*outBuffer] = allocation;
+
+    // VMA manages backing memory — callers do not need the raw VkDeviceMemory
+    if (outMemory) *outMemory = VK_NULL_HANDLE;
     return true;
 }
 
-void VulkanContext::freeBuffer(VkBuffer buffer, VkDeviceMemory memory) {
-    if (device_ == VK_NULL_HANDLE) return;
-    if (buffer != VK_NULL_HANDLE) vkDestroyBuffer(device_, buffer, nullptr);
-    if (memory != VK_NULL_HANDLE) vkFreeMemory(device_, memory, nullptr);
+void VulkanContext::freeBuffer(VkBuffer buffer, VkDeviceMemory /*memory*/) {
+    if (allocator_ == VK_NULL_HANDLE || buffer == VK_NULL_HANDLE) return;
+    auto it = allocationMap_.find(buffer);
+    if (it != allocationMap_.end()) {
+        vmaDestroyBuffer(allocator_, buffer, it->second);
+        allocationMap_.erase(it);
+    }
 }
 
-void* VulkanContext::mapBuffer(VkDeviceMemory memory, VkDeviceSize size) {
+void* VulkanContext::mapBuffer(VkBuffer buffer, VkDeviceSize /*size*/) {
+    auto it = allocationMap_.find(buffer);
+    if (it == allocationMap_.end()) return nullptr;
     void* data = nullptr;
-    vkMapMemory(device_, memory, 0, size, 0, &data);
+    vmaMapMemory(allocator_, it->second, &data);
     return data;
 }
 
-void VulkanContext::unmapBuffer(VkDeviceMemory memory) {
-    vkUnmapMemory(device_, memory);
+void VulkanContext::unmapBuffer(VkBuffer buffer) {
+    auto it = allocationMap_.find(buffer);
+    if (it != allocationMap_.end()) {
+        vmaUnmapMemory(allocator_, it->second);
+    }
 }
 
 // ═══ Command buffer ═══

--- a/libpfsf/src/core/vulkan_context.h
+++ b/libpfsf/src/core/vulkan_context.h
@@ -8,8 +8,10 @@
 #pragma once
 
 #include <vulkan/vulkan.h>
+#include <vk_mem_alloc.h>
 #include <cstdint>
 #include <string>
+#include <unordered_map>
 
 namespace pfsf {
 
@@ -38,20 +40,27 @@ public:
     uint32_t         queueFamily()  const { return computeQueueFamily_; }
     VkCommandPool    cmdPool()      const { return cmdPool_; }
 
-    // ── Buffer operations ──
+    // ── Buffer operations (VMA-backed) ──
 
-    /** Allocate a device-local buffer. Returns {buffer, memory}. */
+    /**
+     * Allocate a device-local buffer via VMA sub-allocation.
+     * outMemory is set to VK_NULL_HANDLE — VMA manages the backing memory internally.
+     * The VmaAllocation is tracked internally and retrieved via freeBuffer().
+     */
     bool allocBuffer(VkDeviceSize size, VkBufferUsageFlags usage,
                      VkBuffer* outBuffer, VkDeviceMemory* outMemory);
 
-    /** Free a buffer + memory pair. */
+    /** Free a VMA-managed buffer. The memory parameter is ignored (VMA owns it). */
     void freeBuffer(VkBuffer buffer, VkDeviceMemory memory);
 
-    /** Map a host-visible buffer. */
-    void* mapBuffer(VkDeviceMemory memory, VkDeviceSize size);
+    /**
+     * Map a host-visible buffer (staging) for CPU write.
+     * Uses VMA-tracked allocation for the given buffer handle.
+     */
+    void* mapBuffer(VkBuffer buffer, VkDeviceSize size);
 
     /** Unmap a previously mapped buffer. */
-    void unmapBuffer(VkDeviceMemory memory);
+    void unmapBuffer(VkBuffer buffer);
 
     // ── Command buffer ──
 
@@ -84,6 +93,11 @@ private:
     VkQueue          computeQueue_   = VK_NULL_HANDLE;
     uint32_t         computeQueueFamily_ = UINT32_MAX;
     VkCommandPool    cmdPool_        = VK_NULL_HANDLE;
+
+    // VMA allocator — owns all GPU buffer sub-allocations
+    VmaAllocator     allocator_      = VK_NULL_HANDLE;
+    // Map from VkBuffer handle → VmaAllocation (for deferred free + map/unmap)
+    std::unordered_map<VkBuffer, VmaAllocation> allocationMap_;
 
     int64_t          deviceLocalBytes_ = 0;
 };


### PR DESCRIPTION
PFSF-1: PFSFFailureApplicator — add missing FAIL_TENSION→TENSION_BREAK
  case in mapFailureType(); tension failures were silently dropped,
  never reaching CollapseManager.

PFSF-2: Full rtens sparse-update chain
  - PFSFSparseUpdate.VoxelUpdate: add rtens field, BYTES 44→48
  - sparse_scatter.comp.glsl: stride 11→12, binding 6 (rtens), writes rtensArr[flatIndex]
  - PFSFEngineInstance.notifyBlockChange(): read & pass rtens from material
  - PFSFPipelineFactory: scatterDSLayout 6→7 bindings
  - PFSFFailureRecorder.recordSparseScatter(): bind rtens at slot 6
  - PFSFIslandBuffer: add getRtensSize() + getFailFlagsSize() helpers

PFSF-3: PFSFDispatcher.recordPhaseFieldEvolve() — binding 5 range fix
  buf.getTypeSize() → buf.getFailFlagsSize() for FailFlags descriptor;
  prevents Vulkan out-of-range access on large islands (type[] >> fail[]).

PFSF-4: PFSFSourceBuilder.injectDiagonalPhantomEdges() — add 8 corner
  offsets (CORNER_FACTOR=0.15, matching SHEAR_CORNER_PENALTY). Previous
  code only handled 12 edge offsets, leaving 8 corner connections absent
  from the 26-connectivity phantom-edge injection.

PFSF-5: libpfsf VMA migration
  - CMakeLists.txt: FetchContent VulkanMemoryAllocator v3.1.0
  - vulkan_context.h: VmaAllocator + allocationMap_ (VkBuffer→VmaAllocation)
  - vulkan_context.cpp: VMA_IMPLEMENTATION; vmaCreateBuffer replaces vkAllocateMemory; vmaDestroyBuffer in freeBuffer; vmaMapMemory / vmaUnmapMemory in mapBuffer/unmapBuffer; VMA init/destroy in init()/shutdown()

