### PR TITLE
refactor: replace creative tab ResourceKey hack with Registries.CREAT…

### DIFF
--- a/Block Reality/api/src/main/java/com/blockreality/api/BlockRealityMod.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/BlockRealityMod.java
@@ -32,7 +32,9 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
+import net.minecraft.core.registries.Registries;
 import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -43,16 +45,8 @@ public class BlockRealityMod {
     private static final Logger LOGGER = LogManager.getLogger("BlockReality");
 
     // ─── Creative Tab ───
-    // 直接建構 ResourceKey 避免 Registries.CREATIVE_MODE_TAB 的 NoSuchFieldError（mappings 相容性）
-    @SuppressWarnings("unchecked")
-    private static final net.minecraft.resources.ResourceKey<net.minecraft.core.Registry<CreativeModeTab>> CREATIVE_TAB_KEY =
-        (net.minecraft.resources.ResourceKey<net.minecraft.core.Registry<CreativeModeTab>>)
-            (net.minecraft.resources.ResourceKey<?>)
-            net.minecraft.resources.ResourceKey.createRegistryKey(
-                new net.minecraft.resources.ResourceLocation("creative_mode_tab"));
-
     public static final DeferredRegister<CreativeModeTab> CREATIVE_TABS =
-        DeferredRegister.create(CREATIVE_TAB_KEY, MOD_ID);
+        DeferredRegister.create(Registries.CREATIVE_MODE_TAB, MOD_ID);
 
     public static final RegistryObject<CreativeModeTab> BR_TAB = CREATIVE_TABS.register("br_tab",
         () -> CreativeModeTab.builder()

--- a/Block Reality/fastdesign/src/main/java/com/blockreality/fastdesign/registry/FdCreativeTab.java
+++ b/Block Reality/fastdesign/src/main/java/com/blockreality/fastdesign/registry/FdCreativeTab.java
@@ -1,6 +1,7 @@
 package com.blockreality.fastdesign.registry;
 
 import com.blockreality.fastdesign.FastDesignMod;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
@@ -12,16 +13,8 @@ import net.minecraftforge.registries.RegistryObject;
  */
 public class FdCreativeTab {
 
-    // 直接建構 ResourceKey 避免 Registries.CREATIVE_MODE_TAB 的 NoSuchFieldError
-    @SuppressWarnings("unchecked")
-    private static final net.minecraft.resources.ResourceKey<net.minecraft.core.Registry<CreativeModeTab>> CREATIVE_TAB_KEY =
-        (net.minecraft.resources.ResourceKey<net.minecraft.core.Registry<CreativeModeTab>>)
-            (net.minecraft.resources.ResourceKey<?>)
-            net.minecraft.resources.ResourceKey.createRegistryKey(
-                new net.minecraft.resources.ResourceLocation("creative_mode_tab"));
-
     public static final DeferredRegister<CreativeModeTab> TABS =
-        DeferredRegister.create(CREATIVE_TAB_KEY, FastDesignMod.MOD_ID);
+        DeferredRegister.create(Registries.CREATIVE_MODE_TAB, FastDesignMod.MOD_ID);
 
     public static final RegistryObject<CreativeModeTab> FD_TAB = TABS.register("fd_tab",
         () -> CreativeModeTab.builder()


### PR DESCRIPTION
…IVE_MODE_TAB

Use the vanilla net.minecraft.core.registries.Registries.CREATIVE_MODE_TAB ResourceKey with DeferredRegister.create() — the standard Forge 1.20.1 pattern.

Previously both BlockRealityMod and FdCreativeTab used an unchecked cast workaround:
  ResourceKey.createRegistryKey(new ResourceLocation("creative_mode_tab"))
to avoid a NoSuchFieldError. That field is ForgeRegistries.CREATIVE_MODE_TABS which does NOT exist in Forge 47.4.13; CreativeModeTab is a vanilla registry.

After this change: no raw cast, no deprecated ResourceLocation(String) constructor, no ForgeRegistries import needed in FdCreativeTab.

