### PR TITLE
fix: replicate 6 local P0-P2 bugs on server branch

### DIFF
--- a/Block Reality/api/src/main/java/com/blockreality/api/client/StressHeatmapRenderer.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/client/StressHeatmapRenderer.java
@@ -92,8 +92,9 @@ public class StressHeatmapRenderer {
         Map<BlockPos, Float> stressCache = ClientStressCache.getCache();
         if (stressCache.isEmpty()) return;
 
-        // ★ D-3c: dirty check — 如果應力資料未變更，跳過重建
-        long worldTick = event.getPartialTick() == 0 ? 0 : System.nanoTime(); // 粗略 tick 代替
+        // ★ D-3c: dirty check — 每 game-tick 最多重建一次（nanoTime 每奈秒變化導致永不跳過，改用 getGameTime）
+        net.minecraft.client.Minecraft mc = net.minecraft.client.Minecraft.getInstance();
+        long worldTick = (mc.level != null) ? mc.level.getGameTime() : 0L;
         if (!meshDirty && lastRebuildTick == worldTick) return;
         meshDirty = false;
         lastRebuildTick = worldTick;

--- a/Block Reality/api/src/main/java/com/blockreality/api/network/CollapseEffectPacket.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/network/CollapseEffectPacket.java
@@ -38,12 +38,19 @@ public class CollapseEffectPacket {
 
     // ─── 序列化 ───
 
+    private static final int MAX_ENCODE_ENTRIES = 65536;
+
     public static void encode(CollapseEffectPacket packet, FriendlyByteBuf buf) {
-        buf.writeInt(packet.collapseData.size());
+        // Cap to MAX_ENCODE_ENTRIES to match the decode guard and prevent oversized packets
+        int count = Math.min(packet.collapseData.size(), MAX_ENCODE_ENTRIES);
+        buf.writeInt(count);
+        int written = 0;
         for (Map.Entry<BlockPos, CollapseInfo> entry : packet.collapseData.entrySet()) {
+            if (written >= count) break;
             buf.writeLong(entry.getKey().asLong());
             buf.writeByte(entry.getValue().type().ordinal());
             buf.writeInt(entry.getValue().materialId());
+            written++;
         }
     }
 

--- a/Block Reality/api/src/main/java/com/blockreality/api/network/FluidSyncPacket.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/network/FluidSyncPacket.java
@@ -3,6 +3,8 @@ package com.blockreality.api.network;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraftforge.network.NetworkEvent;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -17,6 +19,8 @@ import java.util.function.Supplier;
  * <p>客戶端收到後更新本地的渲染用流體狀態，驅動 WaterSurfaceNode 等。
  */
 public class FluidSyncPacket {
+
+    private static final Logger LOGGER = LogManager.getLogger("FluidSyncPacket");
 
     private final Map<BlockPos, FluidEntry> entries;
 
@@ -37,9 +41,10 @@ public class FluidSyncPacket {
 
     public static FluidSyncPacket decode(FriendlyByteBuf buf) {
         int size = buf.readVarInt();
-        // ★ P6-fix: 封包大小防護 (調低至 8192 防止斷線)
-        if (size > 8192) {
-            throw new IllegalStateException("FluidSyncPacket too large: " + size);
+        // ★ P6-fix: 封包大小防護 — 超大封包記錄警告後忽略，不拋出例外（防止斷線）
+        if (size < 0 || size > 8192) {
+            LOGGER.warn("[FluidSyncPacket] Oversized or invalid packet (size={}), dropping", size);
+            return new FluidSyncPacket(new HashMap<>());
         }
         Map<BlockPos, FluidEntry> entries = new HashMap<>(size);
         for (int i = 0; i < size; i++) {

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFBufferManager.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFBufferManager.java
@@ -114,7 +114,7 @@ public final class PFSFBufferManager {
 
     static void freeAll() {
         for (PFSFIslandBuffer buf : buffers.values()) {
-            buf.free();
+            buf.release(); // respect reference counting — was incorrectly calling free() directly
         }
         buffers.clear();
         sparseTrackers.clear();

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFEngineInstance.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFEngineInstance.java
@@ -353,13 +353,15 @@ public final class PFSFEngineInstance implements IPFSFRuntime {
             buf.setWakeTicksRemaining(LOD_WAKE_TICKS);
         }
         // 結構變化（方塊增減）→ BFS 快取失效
-        byte oldType = newMaterial == null ? VOXEL_AIR : VOXEL_SOLID;
-        boolean wasAir = !buf.contains(pos); // 近似判斷
+        // wasAir: use CPU-side lastKnownTypes cache in PFSFSparseUpdate.
+        // !buf.contains(pos) was always false here (early-return above guarantees buf.contains(pos)),
+        // so we instead check the last type written for this position via sparse updates.
+        // Defaults to VOXEL_AIR for unseen positions (correct: first placement is a topology change).
+        int flatIdx = buf.flatIndex(pos);
+        boolean wasAir = (sparse.getLastKnownType(flatIdx) == VOXEL_AIR);
         if (newMaterial == null || wasAir) {
             buf.incrementTopologyVersion();
         }
-
-        int flatIdx = buf.flatIndex(pos);
         float fillRatio = fillRatioLookup != null ? fillRatioLookup.apply(pos) : 1.0f;
         float source = newMaterial != null
                 ? (float) (newMaterial.getDensity() * fillRatio * GRAVITY * BLOCK_VOLUME)

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFSparseUpdate.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFSparseUpdate.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import static com.blockreality.api.physics.pfsf.PFSFConstants.*;
@@ -67,6 +68,13 @@ public final class PFSFSparseUpdate {
     private final ConcurrentLinkedQueue<VoxelUpdate> pendingUpdates = new ConcurrentLinkedQueue<>();
     private boolean fullRebuildRequired = false;
 
+    /**
+     * CPU-side type cache: flatIndex → last written VOXEL_* type.
+     * Used by PFSFEngineInstance.notifyBlockChange() to determine wasAir without
+     * reading back from GPU. Defaults to VOXEL_AIR for unseen positions.
+     */
+    private final Map<Integer, Byte> lastKnownTypes = new ConcurrentHashMap<>();
+
     // ─── GPU 上傳 buffer（小型，常駐 host-visible）───
     /** 最大同時更新數。超過此數觸發全量重建。 */
     private static final int MAX_SPARSE_UPDATES_PER_TICK = 512;
@@ -90,11 +98,22 @@ public final class PFSFSparseUpdate {
      */
     public void markVoxelDirty(VoxelUpdate update) {
         pendingUpdates.add(update);
+        // Track the new type CPU-side so notifyBlockChange() can determine wasAir next time
+        lastKnownTypes.put(update.flatIndex(), update.type());
 
         // 超過閾值 → 退化為全量重建（爆炸等大規模破壞）
         if (pendingUpdates.size() > MAX_SPARSE_UPDATES_PER_TICK) {
             fullRebuildRequired = true;
         }
+    }
+
+    /**
+     * Returns the last known VOXEL_* type for the given flat index.
+     * Returns VOXEL_AIR if the position has never been updated via markVoxelDirty()
+     * (conservative: causes topology version increment on first placement, which is correct).
+     */
+    public byte getLastKnownType(int flatIndex) {
+        return lastKnownTypes.getOrDefault(flatIndex, VOXEL_AIR);
     }
 
     /**
@@ -194,6 +213,7 @@ public final class PFSFSparseUpdate {
             sparseUploadMapped = null;
         }
         pendingUpdates.clear();
+        lastKnownTypes.clear();
     }
 
     /**

--- a/Block Reality/fastdesign/src/main/java/com/blockreality/fastdesign/client/node/NodeRegistry.java
+++ b/Block Reality/fastdesign/src/main/java/com/blockreality/fastdesign/client/node/NodeRegistry.java
@@ -462,7 +462,9 @@ public final class NodeRegistry {
         reg("tool.ui.FontConfig", com.blockreality.fastdesign.client.node.impl.tool.ui.FontConfigNode::new, "Font Config", "字型設定", "tool");
         reg("tool.ui.HUDLayout", com.blockreality.fastdesign.client.node.impl.tool.ui.HUDLayoutNode::new, "HUD Layout", "HUD 佈局", "tool");
 
-        syncToApiNodeGraphIO();
+        // NOTE: syncToApiNodeGraphIO() intentionally not called — it registered null factories
+        // which caused NPE in NodeGraphIO.deserialize() at factory.get(). Deserialization of
+        // fastdesign nodes is handled by fastdesign's own NodeGraphIO, not the API layer.
 
         LOGGER.info("[NodeRegistry] 節點註冊完成，共 {} 種型別", REGISTRY.size());
     }


### PR DESCRIPTION
P0 - PFSFBufferManager.freeAll(): buf.free() → buf.release() to respect reference counting and prevent double-free on shutdown.

P1 - FluidSyncPacket.decode(): replace IllegalStateException throw (which disconnected the player) with a log warning + return empty packet.

P1 - NodeRegistry.syncToApiNodeGraphIO(): remove call that registered null factories into the API layer's NodeGraphIO, causing NPE during node graph deserialization (factory.get() returned null). Fastdesign handles its own deserialization as the comment stated.

P1 - PFSFEngineInstance.notifyBlockChange() wasAir: !buf.contains(pos) was always false after the early-return guard. Add lastKnownTypes ConcurrentHashMap to PFSFSparseUpdate to track CPU-side voxel types; use getLastKnownType() to correctly determine wasAir and trigger incrementTopologyVersion() on block placements into previously-air positions.

P2 - StressHeatmapRenderer: System.nanoTime() changes every nanosecond so lastRebuildTick == worldTick was never true, causing every-frame buffer rebuild. Replace with level.getGameTime() for a stable per-tick counter.

P2 - CollapseEffectPacket.encode(): add MAX_ENCODE_ENTRIES = 65536 cap to match the existing decode guard and prevent oversized network packets.

