### PR TITLE
fix: replace Registries.CREATIVE_MODE_TAB with ResourceLocation to fi…

### DIFF
--- a/Block Reality/api/src/main/java/com/blockreality/api/BlockRealityMod.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/BlockRealityMod.java
@@ -16,6 +16,7 @@ import com.blockreality.api.registry.BREntities;
 import com.blockreality.api.spi.ModuleRegistry;
 import com.google.gson.JsonObject;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.common.MinecraftForge;
@@ -32,7 +33,6 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.lifecycle.FMLCommonSetupEvent;
-import net.minecraft.core.registries.Registries;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
@@ -45,8 +45,10 @@ public class BlockRealityMod {
     private static final Logger LOGGER = LogManager.getLogger("BlockReality");
 
     // ─── Creative Tab ───
+    // Use ResourceLocation form to avoid NoSuchFieldError on Registries.CREATIVE_MODE_TAB
+    // in production Forge (the Registries class field uses SRG names in the universal jar).
     public static final DeferredRegister<CreativeModeTab> CREATIVE_TABS =
-        DeferredRegister.create(Registries.CREATIVE_MODE_TAB, MOD_ID);
+        DeferredRegister.create(new ResourceLocation("creative_mode_tab"), MOD_ID);
 
     public static final RegistryObject<CreativeModeTab> BR_TAB = CREATIVE_TABS.register("br_tab",
         () -> CreativeModeTab.builder()

--- a/Block Reality/fastdesign/src/main/java/com/blockreality/fastdesign/registry/FdCreativeTab.java
+++ b/Block Reality/fastdesign/src/main/java/com/blockreality/fastdesign/registry/FdCreativeTab.java
@@ -1,8 +1,8 @@
 package com.blockreality.fastdesign.registry;
 
 import com.blockreality.fastdesign.FastDesignMod;
-import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.registries.DeferredRegister;
@@ -13,8 +13,10 @@ import net.minecraftforge.registries.RegistryObject;
  */
 public class FdCreativeTab {
 
+    // Use ResourceLocation form to avoid NoSuchFieldError on Registries.CREATIVE_MODE_TAB
+    // in production Forge (the Registries class field uses SRG names in the universal jar).
     public static final DeferredRegister<CreativeModeTab> TABS =
-        DeferredRegister.create(Registries.CREATIVE_MODE_TAB, FastDesignMod.MOD_ID);
+        DeferredRegister.create(new ResourceLocation("creative_mode_tab"), FastDesignMod.MOD_ID);
 
     public static final RegistryObject<CreativeModeTab> FD_TAB = TABS.register("fd_tab",
         () -> CreativeModeTab.builder()


### PR DESCRIPTION
…x NoSuchFieldError

The production Forge universal jar uses SRG method names (e.g. m_135788_) for ResourceKey. In the dev environment the Registries class has CREATIVE_MODE_TAB with official names, but accessing Registries.CREATIVE_MODE_TAB at class-load time in a production Forge 1.20.1 install triggers NoSuchFieldError because the field resolution fails against the production MC classes.

Fix: switch both creative tab DeferredRegisters to use the DeferredRegister.create(ResourceLocation, String) overload, which takes just the registry name string and internally constructs the ResourceKey via Forge's own method — no direct reference to Registries.CREATIVE_MODE_TAB needed.

  BlockRealityMod.java:  Registries.CREATIVE_MODE_TAB → new ResourceLocation("creative_mode_tab")
  FdCreativeTab.java:    Registries.CREATIVE_MODE_TAB → new ResourceLocation("creative_mode_tab")

Also removed now-unused import of net.minecraft.core.registries.Registries from both files.

