### PR TITLE
fix(physics): 修復 PR #158 審計發現的三項真實 bug

### DIFF
--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/LoadPathEngine.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/LoadPathEngine.java
@@ -144,7 +144,13 @@ public class LoadPathEngine {
      */
     public static int onBlockBroken(ServerLevel level, BlockPos brokenPos) {
         BlockEntity be = level.getBlockEntity(brokenPos);
-        if (!(be instanceof RBlockEntity rbe)) return 0;
+        if (!(be instanceof RBlockEntity rbe)) {
+            // 非 RBlockEntity（原版方塊如石頭、黑曜石等）被破壞：
+            // 自身無 LoadPath 資料可移除（cachedParent=null, cachedLoad=0f），
+            // 但若有 RBlock 以此位置為 supportParent（findBestSupport DOWN score=100），
+            // 仍需觸發孤兒重連 / 級聯崩塌邏輯，否則其上的 RBlock 塔不會倒。
+            return onBlockBrokenCached(level, brokenPos, null, 0f);
+        }
 
         float totalLoad = rbe.getCurrentLoad();
         BlockPos parent = rbe.getSupportParent();

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/DescriptorPoolManager.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/DescriptorPoolManager.java
@@ -105,12 +105,15 @@ public final class DescriptorPoolManager {
     /** 取得容量使用率 */
     public float getUsageRatio() { return maxSets > 0 ? (float) allocatedSets / maxSets : 0; }
 
-    private boolean isDestroyed = false;
+    // AtomicBoolean 保證 destroy() 在多執行緒下（Forge Tick + async Vulkan Callback）
+    // 只執行一次：compareAndSet(false, true) 是原子操作，
+    // 避免兩個執行緒同時看到 false 而各自執行 destroyDescriptorPool()（double-free）。
+    private final java.util.concurrent.atomic.AtomicBoolean isDestroyed =
+            new java.util.concurrent.atomic.AtomicBoolean(false);
 
-    /** 銷毀底層 pool */
+    /** 銷毀底層 pool（冪等：多次呼叫安全，僅首次生效） */
     public void destroy() {
-        if (isDestroyed) return;
-        isDestroyed = true;
+        if (!isDestroyed.compareAndSet(false, true)) return;
         if (pool != 0L) {
             VulkanComputeContext.destroyDescriptorPool(pool);
         }

--- a/Block Reality/api/src/main/java/com/blockreality/api/sidecar/SidecarBridge.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/sidecar/SidecarBridge.java
@@ -468,16 +468,28 @@ public class SidecarBridge {
         // 在等待期間永遠無法取得 — 服務器關閉時最多被阻塞 timeoutMs 秒。
         // 解法：在 readLock 內只做 O(1) 的 running check + request send，然後釋放 lock，
         // 再在 lock 外 await future。
+        //
+        // ★ TOCTOU fix: 原本在 try 內手動 readLock.unlock() → tryReconnect() → readLock.lock()，
+        // 若 tryReconnect() 拋出 RuntimeException，finally 的 unlock() 會炸
+        // IllegalMonitorStateException（鎖已釋放但 finally 再次 unlock）。
+        // 修正：用 readLockAcquired 追蹤鎖狀態，finally 依此決定是否 unlock。
         int id = -1;
         CompletableFuture<JsonObject> future = new CompletableFuture<>();
+        boolean readLockAcquired = false;
 
-        stateLock.readLock().lock();
         try {
+            stateLock.readLock().lock();
+            readLockAcquired = true;
+
             // ★ 偵測行程已死但 running 尚未更新的情況，嘗試自動重連
             if (!running || writer == null || (nodeProcess != null && !nodeProcess.isAlive())) {
                 stateLock.readLock().unlock();
+                readLockAcquired = false;
+                // tryReconnect() 內部呼叫 stop()/start()，會取得 writeLock；
+                // 此時我們未持有任何鎖，不會造成 deadlock 或 IllegalMonitorStateException。
                 boolean reconnected = tryReconnect();
                 stateLock.readLock().lock();
+                readLockAcquired = true;
                 if (!reconnected || !running || writer == null) {
                     throw new SidecarException("Sidecar 未啟動或已崩潰，自動重連失敗");
                 }
@@ -518,7 +530,9 @@ public class SidecarBridge {
             if (id != -1) pending.remove(id);
             throw e;
         } finally {
-            stateLock.readLock().unlock();
+            if (readLockAcquired) {
+                stateLock.readLock().unlock();
+            }
         }
 
         // ★ N1: 在 readLock 外 await，stop() 可隨時取得 writeLock


### PR DESCRIPTION
1. LoadPathEngine.onBlockBroken — 原版方塊（非 RBlockEntity）被破壞時 直接 return 0，導致其上的 RBlock 塔不觸發孤兒/崩塌邏輯。 修正：委派至 onBlockBrokenCached(level, pos, null, 0f)， 保留孤兒搜尋與級聯崩塌流程。

2. DescriptorPoolManager.destroy — isDestroyed 為普通 boolean， Forge async Tick 與 Vulkan callback 同時呼叫時有 double-free 風險。 修正：改用 AtomicBoolean.compareAndSet(false, true) 原子操作， 確保 destroyDescriptorPool() 只執行一次。

3. SidecarBridge.call — 在 readLock 持有期間手動 unlock() 後呼叫 tryReconnect()，若 tryReconnect() 拋出 RuntimeException， finally 的 unlock() 會炸 IllegalMonitorStateException。 修正：以 readLockAcquired boolean 追蹤鎖狀態，finally 依此決定 是否 unlock，消除 TOCTOU 與例外路徑的鎖不一致問題。

