### PR TITLE
fix(build): 修復崩潰報告中三項導致 NoSuchMethodError 的根本原因

### DIFF
--- a/Block Reality/api/build.gradle
+++ b/Block Reality/api/build.gradle
@@ -131,7 +131,10 @@ jar {
             'Specification-Vendor'    : 'BlockReality',
             'Implementation-Title'    : project.name,
             'Implementation-Version'  : project.jar.archiveVersion,
-            'Implementation-Vendor'   : 'BlockReality'
+            'Implementation-Vendor'   : 'BlockReality',
+            // ★ Forge 需要此屬性才會套用 accesstransformer.cfg；
+            //   缺少時 AT 檔案雖在 jar 內但完全被忽略。
+            'FMLAT'                   : 'accesstransformer.cfg'
         ])
     }
 }

--- a/Block Reality/api/src/main/resources/META-INF/mods.toml
+++ b/Block Reality/api/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,8 @@
 modLoader   = "javafml"
-loaderVersion = "[47,)"
+# [47.2,) matches the dependency versionRange below.
+# Using [47,) would let Forge 47.0.x/47.1.x start loading the @Mod class
+# before the dependency check fires, hitting NoSuchMethodError.
+loaderVersion = "[47.2,)"
 license     = "MIT"
 
 [[mods]]

--- a/Block Reality/build.gradle
+++ b/Block Reality/build.gradle
@@ -39,8 +39,15 @@ subprojects {
 
 // ─── 合併 JAR：api + fastdesign → mpd.jar ───
 // 拿到手就能丟 mods/ 資料夾使用，不需額外安裝
+//
+// ★ 使用 reobfJar（而非 jar）：
+//   ForgeGradle 6 的 jar 任務輸出的是開發用 jar（使用 official/mojmap 名稱）。
+//   生產 Forge 1.20.1 在載入 mod 時仍以 SRG 名稱為基準，再將 SRG→official 映射。
+//   若 mod jar 已是 official 名稱，Forge 的 SRG→official 映射會把方法名稱二次映射成
+//   不存在的名稱，導致 BlockBehaviour$Properties.of()、EntityType$Builder.of() 等
+//   NoSuchMethodError。reobfJar 輸出為 SRG 名稱的 jar，才是 Forge 期待的格式。
 task mergedJar(type: Jar) {
-    dependsOn ':api:jar', ':fastdesign:jar'
+    dependsOn ':api:reobfJar', ':fastdesign:reobfJar'
 
     archiveBaseName = 'mpd'
     archiveVersion  = ''
@@ -48,16 +55,16 @@ task mergedJar(type: Jar) {
     archiveAppendix = ''
     destinationDirectory = file("${rootProject.projectDir}/../")   // → project/mpd.jar
 
-    // 合併 api classes + resources（排除 mods.toml 和 pack.mcmeta，後面統一放）
-    from(project(':api').zipTree(project(':api').tasks.jar.archiveFile)) {
+    // 合併 api reobf classes + resources（排除 mods.toml 和 pack.mcmeta，後面統一放）
+    from(project(':api').zipTree(project(':api').tasks.reobfJar.archiveFile)) {
         exclude 'META-INF/mods.toml'
         exclude 'META-INF/MANIFEST.MF'
         exclude 'pack.mcmeta'
         // 保留 META-INF/jarjar/（LWJGL JarInJar 嵌入）
     }
 
-    // 合併 fastdesign classes + resources
-    from(project(':fastdesign').zipTree(project(':fastdesign').tasks.jar.archiveFile)) {
+    // 合併 fastdesign reobf classes + resources
+    from(project(':fastdesign').zipTree(project(':fastdesign').tasks.reobfJar.archiveFile)) {
         exclude 'META-INF/mods.toml'
         exclude 'META-INF/MANIFEST.MF'
         exclude 'pack.mcmeta'
@@ -72,8 +79,8 @@ task mergedJar(type: Jar) {
         include 'pack.mcmeta'
     }
 
-    // AT 檔保留
-    from(project(':api').zipTree(project(':api').tasks.jar.archiveFile)) {
+    // AT 檔保留（從 reobfJar 取出）
+    from(project(':api').zipTree(project(':api').tasks.reobfJar.archiveFile)) {
         include 'META-INF/accesstransformer.cfg'
     }
 
@@ -83,7 +90,10 @@ task mergedJar(type: Jar) {
             'Specification-Vendor'    : 'BlockReality',
             'Implementation-Title'    : 'Block Reality + Fast Design',
             'Implementation-Version'  : '1.0.0',
-            'Implementation-Vendor'   : 'BlockReality'
+            'Implementation-Vendor'   : 'BlockReality',
+            // ★ FMLAT 必須聲明，否則 Forge 不會套用 accesstransformer.cfg，
+            //   即使 AT 檔案已包含在 jar 內也無效。
+            'FMLAT'                   : 'accesstransformer.cfg'
         ])
     }
 

--- a/Block Reality/merged-resources/META-INF/mods.toml
+++ b/Block Reality/merged-resources/META-INF/mods.toml
@@ -1,5 +1,9 @@
 modLoader   = "javafml"
-loaderVersion = "[47,)"
+# [47.2,) matches the dependency versionRange below.
+# Using [47,) would let Forge 47.0.x/47.1.x start loading the @Mod class
+# before the dependency check fires, hitting NoSuchMethodError for APIs
+# that were added/stabilised in 47.2.x (CreativeModeTab.builder, etc.).
+loaderVersion = "[47.2,)"
 license     = "MIT"
 
 # ─── Block Reality API ───


### PR DESCRIPTION
根本原因 1 — loaderVersion 過於寬鬆 [47,) → [47.2,)
  merged-resources/META-INF/mods.toml 和 api/mods.toml 都宣告
  loaderVersion = "[47,)"，允許 Forge 47.0.x/47.1.x 開始載入 @Mod 類別。
  dependency versionRange = "[47.2.0,)" 的檢查在 CONSTRUCT 階段之後，
  此時 BlockBehaviour.Properties.of() 等只存在於 ≥47.2 的 API 已被呼叫，
  導致 NoSuchMethodError。修正：改為 [47.2,)，讓版本檢查在類別載入前失敗。

根本原因 2 — mergedJar 使用 dev jar（mojmap 名稱）而非 reobfJar（SRG 名稱）
  FG6 的 jar 任務輸出使用 official（mojmap）名稱的開發 jar。
  生產 Forge 1.20.1 以 SRG 名稱為基準，載入 mod 時將 SRG→official 映射。
  若 mod jar 已是 official 名稱，映射結果為不存在的名稱 →
  BlockBehaviour$Properties.of()、EntityType$Builder.of()、
  CreativeModeTab$Builder.icon() 皆拋 NoSuchMethodError，
  隨後 blockreality:r_concrete 未能建立 → NullPointerException。
  修正：mergedJar 改為 dependsOn ':api:reobfJar', ':fastdesign:reobfJar'
  並使用 tasks.reobfJar.archiveFile。

根本原因 3 — mergedJar manifest 缺少 FMLAT 屬性
  accesstransformer.cfg 雖然被包含在 jar 內，但 Forge 需要 MANIFEST.MF 中
  的 FMLAT 屬性才會套用 AT。缺少時 AT 完全被忽略，可能導致後續存取非公開
  成員時拋 IllegalAccessError。
  修正：在 mergedJar manifest 及 api jar manifest 中加入
  'FMLAT': 'accesstransformer.cfg'。

