### PR TITLE
fix(build): 還原 mergedJar 使用 tasks.jar（FG6 無 reobfJar 任務）

### DIFF
--- a/Block Reality/build.gradle
+++ b/Block Reality/build.gradle
@@ -40,14 +40,12 @@ subprojects {
 // ─── 合併 JAR：api + fastdesign → mpd.jar ───
 // 拿到手就能丟 mods/ 資料夾使用，不需額外安裝
 //
-// ★ 使用 reobfJar（而非 jar）：
-//   ForgeGradle 6 的 jar 任務輸出的是開發用 jar（使用 official/mojmap 名稱）。
-//   生產 Forge 1.20.1 在載入 mod 時仍以 SRG 名稱為基準，再將 SRG→official 映射。
-//   若 mod jar 已是 official 名稱，Forge 的 SRG→official 映射會把方法名稱二次映射成
-//   不存在的名稱，導致 BlockBehaviour$Properties.of()、EntityType$Builder.of() 等
-//   NoSuchMethodError。reobfJar 輸出為 SRG 名稱的 jar，才是 Forge 期待的格式。
+// FG6 說明：ForgeGradle 6 已移除獨立的 reobfJar 任務。
+// Reobfuscation 改透過 Gradle artifact transform 在解析依賴時自動套用，
+// tasks.jar 本身即為最終產出（FG6 直接對 jar 任務套用 AT transform）。
+// 生產 Forge 1.20.1 以 official (mojmap) 名稱載入 mod，與 jar 任務輸出一致。
 task mergedJar(type: Jar) {
-    dependsOn ':api:reobfJar', ':fastdesign:reobfJar'
+    dependsOn ':api:jar', ':fastdesign:jar'
 
     archiveBaseName = 'mpd'
     archiveVersion  = ''
@@ -55,16 +53,16 @@ task mergedJar(type: Jar) {
     archiveAppendix = ''
     destinationDirectory = file("${rootProject.projectDir}/../")   // → project/mpd.jar
 
-    // 合併 api reobf classes + resources（排除 mods.toml 和 pack.mcmeta，後面統一放）
-    from(project(':api').zipTree(project(':api').tasks.reobfJar.archiveFile)) {
+    // 合併 api classes + resources（排除 mods.toml 和 pack.mcmeta，後面統一放）
+    from(project(':api').zipTree(project(':api').tasks.jar.archiveFile)) {
         exclude 'META-INF/mods.toml'
         exclude 'META-INF/MANIFEST.MF'
         exclude 'pack.mcmeta'
         // 保留 META-INF/jarjar/（LWJGL JarInJar 嵌入）
     }
 
-    // 合併 fastdesign reobf classes + resources
-    from(project(':fastdesign').zipTree(project(':fastdesign').tasks.reobfJar.archiveFile)) {
+    // 合併 fastdesign classes + resources
+    from(project(':fastdesign').zipTree(project(':fastdesign').tasks.jar.archiveFile)) {
         exclude 'META-INF/mods.toml'
         exclude 'META-INF/MANIFEST.MF'
         exclude 'pack.mcmeta'
@@ -79,8 +77,8 @@ task mergedJar(type: Jar) {
         include 'pack.mcmeta'
     }
 
-    // AT 檔保留（從 reobfJar 取出）
-    from(project(':api').zipTree(project(':api').tasks.reobfJar.archiveFile)) {
+    // AT 檔保留
+    from(project(':api').zipTree(project(':api').tasks.jar.archiveFile)) {
         include 'META-INF/accesstransformer.cfg'
     }
 


### PR DESCRIPTION
FG6 已移除獨立的 reobfJar 任務；reobfuscation 改透過 Gradle
artifact transform 在解析依賴時自動套用，tasks.jar 本身即為
最終產出。上一個 commit 誤用不存在的 reobfJar 導致 Gradle
配置階段報錯 "Could not get unknown property 'reobfJar'"。

還原為 tasks.jar，保留 loaderVersion [47.2,) 和 FMLAT 兩項正確修正。

