### PR TITLE
fix(nn): 統一 SSGO 訓練/推理通道數 6ch→7ch，加入 anchor 邊界條件通道

### DIFF
--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/BIFROSTModelRegistry.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/BIFROSTModelRegistry.java
@@ -43,9 +43,9 @@ public final class BIFROSTModelRegistry {
     /** Standard model directory relative to game root. */
     private static final String MODEL_DIR = "config/blockreality/models";
 
-    /** Known model contract IDs and their expected output channel counts. */
+    /** Known model contract IDs and their expected channel counts. */
     private static final Map<String, ModelSpec> SPECS = Map.of(
-        "bifrost_surrogate", new ModelSpec(6, 10, "structural physics"),
+        "bifrost_surrogate", new ModelSpec(7, 10, "structural physics"),  // 7ch: occ,E,nu,rho,rcomp,rtens,anchor
         "bifrost_fluid",     new ModelSpec(8, 4, "water simulation"),
         "bifrost_lod",       new ModelSpec(14, 4, "chunk LOD tier"),
         "bifrost_collapse",  new ModelSpec(8, 5, "collapse prediction")

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/OnnxPFSFRuntime.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/OnnxPFSFRuntime.java
@@ -17,7 +17,7 @@ import java.util.function.Function;
  * ONNX-based PFSF runtime — loads a trained FNO3DMultiField model
  * and runs inference for irregular structures.
  *
- * <p>Input (5 channels): [1, L, L, L, 5] — occ, E, ν, ρ, Rcomp (normalized)</p>
+ * <p>Input (7 channels): [1, L, L, L, 7] — occ, E, ν, ρ, Rcomp, Rtens, anchor (normalized)</p>
  * <p>Output (10 channels): [1, L, L, L, 10] — σ(6) + u(3) + φ(1)</p>
  *
  * <p>The φ channel (index 9) is fed directly into the existing PFSF failure
@@ -71,13 +71,13 @@ public class OnnxPFSFRuntime {
 
             session = env.createSession(modelPath, opts);
 
-            // Extract grid size from input shape: [1, L, L, L, 5]
+            // Extract grid size from input shape: [1, L, L, L, 7]
             Map<String, NodeInfo> inputs = session.getInputInfo();
             if (!inputs.isEmpty()) {
                 NodeInfo firstInput = inputs.values().iterator().next();
                 if (firstInput.getInfo() instanceof TensorInfo ti) {
                     long[] shape = ti.getShape();
-                    if (shape.length == 5 && (shape[4] == 5 || shape[4] == 6)) {
+                    if (shape.length == 5 && shape[4] >= 5 && shape[4] <= 7) {
                         gridSize = (int) shape[1];
                     }
                 }
@@ -141,9 +141,11 @@ public class OnnxPFSFRuntime {
         BlockPos origin = new BlockPos(minX, minY, minZ);
 
         try {
-            // ── Build input tensor [1, L, L, L, 5] in row-major order ──
-            // Index: batch*L*L*L*5 + x*L*L*5 + y*L*5 + z*5 + channel
-            float[] input = new float[1 * L * L * L * 6];
+            // ── Build input tensor [1, L, L, L, 7] in row-major order ──
+            // Channels: occ, E, nu, rho, Rcomp, Rtens, anchor
+            // MUST match Python training normalization (train_robust_ssgo.py build_input)
+            int C = 7;
+            float[] input = new float[1 * L * L * L * C];
 
             for (BlockPos pos : members) {
                 int ix = pos.getX() - minX;
@@ -153,18 +155,21 @@ public class OnnxPFSFRuntime {
                 RMaterial mat = materialLookup.apply(pos);
                 if (mat == null) continue;
 
-                int base = ((ix * L + iy) * L + iz) * 6;
+                int base = ((ix * L + iy) * L + iz) * C;
 
-                // 6ch — must match Python training normalization
+                // 7ch — must match Python training normalization
                 input[base]     = 1.0f;                                          // occupancy
                 input[base + 1] = (float)(mat.getYoungsModulusPa() / E_SCALE);  // E
                 input[base + 2] = (float) mat.getPoissonsRatio();                // nu
                 input[base + 3] = (float)(mat.getDensity() / RHO_SCALE);         // density
                 input[base + 4] = (float)(mat.getRcomp() / RC_SCALE);            // Rcomp
                 input[base + 5] = (float)(mat.getRtens() / RT_SCALE);            // Rtens
+                // anchor: 1.0 = fixed support, 0.0 = free body
+                input[base + 6] = (anchorLookup != null && anchorLookup.apply(pos))
+                                  ? 1.0f : 0.0f;
             }
 
-            long[] shape = {1, L, L, L, 6};
+            long[] shape = {1, L, L, L, C};
             OnnxTensor inputTensor = OnnxTensor.createTensor(env, FloatBuffer.wrap(input), shape);
 
             // ── Run inference ──

--- a/ml/BR-NeXT/brnext/export/contract_adapter.py
+++ b/ml/BR-NeXT/brnext/export/contract_adapter.py
@@ -19,9 +19,9 @@ class ContractViolationError(Exception):
 def validate_surrogate_contract(onnx_path: str | Path) -> None:
     """Smoke-test an ONNX file against the surrogate contract.
 
-    Contract (from brml.export.onnx_contracts):
-      input:  [1, -1, -1, -1, 6] float32
-      output: [1, -1, -1, -1, 10] float32
+    Contract (must match Java OnnxPFSFRuntime + Python train_robust_ssgo):
+      input:  [1, -1, -1, -1, 7] float32  (occ, E, nu, rho, rcomp, rtens, anchor)
+      output: [1, -1, -1, -1, 10] float32 (stress(6) + disp(3) + phi(1))
     """
     try:
         import onnx
@@ -48,10 +48,10 @@ def validate_surrogate_contract(onnx_path: str | Path) -> None:
     in_shape = inputs[0].shape
     out_shape = outputs[0].shape
 
-    # Validate dims
-    if len(in_shape) != 5 or in_shape[0] != 1 or in_shape[4] != 6:
+    # Validate dims — 7 input channels (occ, E, nu, rho, rcomp, rtens, anchor)
+    if len(in_shape) != 5 or in_shape[0] != 1 or in_shape[4] != 7:
         raise ContractViolationError(
-            f"Input shape contract violation: expected [1, L, L, L, 6], got {in_shape}"
+            f"Input shape contract violation: expected [1, L, L, L, 7], got {in_shape}"
         )
     if len(out_shape) != 5 or out_shape[0] != 1 or out_shape[4] != 10:
         raise ContractViolationError(
@@ -62,7 +62,7 @@ def validate_surrogate_contract(onnx_path: str | Path) -> None:
     # Infer grid size from the fixed spatial dims of the exported model
     in_shape = inputs[0].shape
     L = in_shape[1] if isinstance(in_shape[1], int) else 8
-    dummy = np.zeros((1, L, L, L, 6), dtype=np.float32)
+    dummy = np.zeros((1, L, L, L, 7), dtype=np.float32)
     result = sess.run(None, {inputs[0].name: dummy})
     if result[0].shape != (1, L, L, L, 10):
         raise ContractViolationError(

--- a/ml/BR-NeXT/brnext/export/manual_onnx.py
+++ b/ml/BR-NeXT/brnext/export/manual_onnx.py
@@ -378,12 +378,12 @@ def export_ssgo_manual(params, output_path: str | Path, grid_size: int = 12,
     L = grid_size
     B = 1
     input_name = "input"
-    b.add_input(input_name, [B, L, L, L, 6])
+    b.add_input(input_name, [B, L, L, L, 7])
     h = b._next
 
     # Helper to track shape manually
     cur = input_name
-    cur_shape = (B, L, L, L, 6)
+    cur_shape = (B, L, L, L, 7)
 
     def _dense(path_prefix, in_ch, out_ch):
         nonlocal cur, cur_shape
@@ -718,7 +718,7 @@ def export_ssgo_manual(params, output_path: str | Path, grid_size: int = 12,
     # =========================== Build Graph ===========================
     # Global branch lifting
     global_in = cur
-    _dense("Dense_0", 6, hidden)
+    _dense("Dense_0", 7, hidden)
 
     # FNOBlocks global
     for gi in range(n_global_layers):
@@ -727,8 +727,8 @@ def export_ssgo_manual(params, output_path: str | Path, grid_size: int = 12,
 
     # Focal branch lifting
     cur = global_in  # back to input
-    cur_shape = (B, L, L, L, 6)
-    _dense("Dense_1", 6, hidden)
+    cur_shape = (B, L, L, L, 7)
+    _dense("Dense_1", 7, hidden)
 
     # Voxel GAT layers
     for fi in range(n_focal_layers):

--- a/ml/BR-NeXT/brnext/export/onnx_export.py
+++ b/ml/BR-NeXT/brnext/export/onnx_export.py
@@ -121,7 +121,7 @@ def main():
     from brnext.models.ssgo import SSGO
     model = SSGO()
     rng = jax.random.PRNGKey(0)
-    dummy = (jnp.zeros((1, args.grid, args.grid, args.grid, 6)),)
+    dummy = (jnp.zeros((1, args.grid, args.grid, args.grid, 7)),)
     variables = model.init(rng, *dummy)
 
     # Load checkpoint

--- a/ml/BR-NeXT/brnext/models/ssgo.py
+++ b/ml/BR-NeXT/brnext/models/ssgo.py
@@ -31,7 +31,7 @@ class SSGO(nn.Module):
     def __call__(self, x: jnp.ndarray, train: bool = False) -> jnp.ndarray:
         """
         Args:
-            x: [B, L, L, L, 6]
+            x: [B, L, L, L, 7]  (occ, E_norm, nu, rho_norm, rcomp_norm, rtens_norm, anchor)
             train: whether to apply dropout
         Returns:
             [B, L, L, L, 10]  or  [B, L, L, L, 11] if output_uncertainty=True

--- a/ml/BR-NeXT/brnext/pipeline/cmfd_trainer.py
+++ b/ml/BR-NeXT/brnext/pipeline/cmfd_trainer.py
@@ -142,7 +142,7 @@ class CMFDTrainer:
         model = self._build_model()
         rng = jax.random.PRNGKey(self.cfg.seed)
         L = self.cfg.grid_size
-        dummy = jnp.zeros((1, L, L, L, 6))
+        dummy = jnp.zeros((1, L, L, L, 7))
         variables = model.init(rng, dummy)
 
         opt = optax.chain(
@@ -462,7 +462,8 @@ class CMFDTrainer:
         rho = jnp.array(struct.density_field) / norm["RHO_SCALE"]
         rc = jnp.array(struct.rcomp_field) / norm["RC_SCALE"]
         rt = jnp.array(struct.rtens_field) / norm["RT_SCALE"]
-        return jnp.stack([occ, E, nu, rho, rc, rt], axis=-1)
+        anchor = jnp.array(struct.anchors, dtype=jnp.float32)
+        return jnp.stack([occ, E, nu, rho, rc, rt, anchor], axis=-1)
 
     def _export(self, model, params):
         self._log("\n═══ Exporting ONNX ═══")
@@ -471,7 +472,7 @@ class CMFDTrainer:
         from brnext.export.onnx_export import export_ssgo_to_onnx
         from brnext.config import _CONFIG_PATH
         L = self.cfg.grid_size
-        dummy = (jnp.zeros((1, L, L, L, 6)),)
+        dummy = (jnp.zeros((1, L, L, L, 7)),)
         onnx_path = self.output_dir / "brnext_ssgo.onnx"
         try:
             export_ssgo_to_onnx(model, params, dummy, str(onnx_path))

--- a/ml/BR-NeXT/brnext/train/train_robust_ssgo.py
+++ b/ml/BR-NeXT/brnext/train/train_robust_ssgo.py
@@ -472,7 +472,7 @@ class RobustTrainer:
         self._log("\n═══ Exporting ONNX ═══")
         from brnext.export.onnx_export import export_ssgo_to_onnx
         L = self.cfg.grid_size
-        dummy = jnp.zeros((1, L, L, L, 7))
+        dummy = (jnp.zeros((1, L, L, L, 7)),)  # tuple of arrays, matching export_ssgo_to_onnx signature
         onnx_path = self.output_dir / "ssgo_robust_medium.onnx"
         try:
             export_ssgo_to_onnx(model, params, dummy, str(onnx_path))

--- a/ml/BR-NeXT/tests/test_ssgo_forward.py
+++ b/ml/BR-NeXT/tests/test_ssgo_forward.py
@@ -10,7 +10,7 @@ def test_ssgo_output_shape():
                  n_focal_layers=1, n_backbone_layers=1, moe_hidden=16)
     rng = jax.random.PRNGKey(0)
     B, L = 2, 8
-    x = jnp.ones((B, L, L, L, 6))
+    x = jnp.ones((B, L, L, L, 7))
     variables = model.init(rng, x)
     out = model.apply(variables, x)
     assert out.shape == (B, L, L, L, 10)
@@ -21,11 +21,11 @@ def test_ssgo_zero_in_air():
                  n_focal_layers=1, n_backbone_layers=1, moe_hidden=16)
     rng = jax.random.PRNGKey(1)
     B, L = 1, 6
-    x = jnp.zeros((B, L, L, L, 6))
+    x = jnp.zeros((B, L, L, L, 7))
     x = x.at[..., 0].set(1.0)  # occupancy=1 everywhere for this test
     variables = model.init(rng, x)
     out = model.apply(variables, x)
     # All channels should be zero where occupancy is zero
-    x_air = jnp.zeros((B, L, L, L, 6))
+    x_air = jnp.zeros((B, L, L, L, 7))
     out_air = model.apply(variables, x_air)
     assert jnp.allclose(out_air, 0.0)

--- a/ml/HYBR/hybr/core/materialize.py
+++ b/ml/HYBR/hybr/core/materialize.py
@@ -102,7 +102,7 @@ def materialize_static_ssgo(
         n_backbone_layers=adaptive_model.n_backbone_layers,
         moe_hidden=adaptive_model.moe_hidden,
     )
-    dummy_x = jnp.zeros((B, L, L, L, 6))
+    dummy_x = jnp.zeros((B, L, L, L, 7))
     static_vars = static_model.init(jax.random.PRNGKey(0), dummy_x)
     static_params = dict(static_vars["params"])
 

--- a/ml/HYBR/hybr/training/meta_trainer.py
+++ b/ml/HYBR/hybr/training/meta_trainer.py
@@ -201,7 +201,7 @@ class HYBRTrainer:
 
         rng = jax.random.PRNGKey(self.cfg.seed)
         L = self.cfg.grid_size
-        dummy = jnp.zeros((1, L, L, L, 6))
+        dummy = jnp.zeros((1, L, L, L, 7))
         variables = model.init(rng, dummy, update_stats=False, mutable=["params", "batch_stats"])
         params = variables["params"]
         batch_stats = variables.get("batch_stats", {})
@@ -328,7 +328,7 @@ class HYBRTrainer:
         static_params, static_model = materialize_static_ssgo(model, variables, occ)
 
         onnx_path = self.output_dir / "hybr_ssgo.onnx"
-        dummy = (jnp.zeros((1, L, L, L, 6)),)
+        dummy = (jnp.zeros((1, L, L, L, 7)),)
         export_ssgo_to_onnx(
             static_model,
             static_params,

--- a/ml/HYBR/scripts/train_hybr.py
+++ b/ml/HYBR/scripts/train_hybr.py
@@ -329,7 +329,7 @@ def main():
 
     rng = jax.random.PRNGKey(cfg["seed"])
     L = cfg["grid_size"]
-    dummy = jnp.zeros((1, L, L, L, 6))
+    dummy = jnp.zeros((1, L, L, L, 7))
     print("Initializing AdaptiveSSGO...")
     variables = model.init(rng, dummy, update_stats=False, mutable=["params", "batch_stats"])
 

--- a/ml/HYBR/tests/test_adaptive_ssgo_forward.py
+++ b/ml/HYBR/tests/test_adaptive_ssgo_forward.py
@@ -33,7 +33,7 @@ def test_adaptive_ssgo_init_and_forward():
     )
 
     rng = jax.random.PRNGKey(0)
-    dummy_x = jnp.zeros((B, L, L, L, 6))
+    dummy_x = jnp.zeros((B, L, L, L, 7))
 
     # Init requires mutable=['params', 'batch_stats'] because of SpectralNorm
     variables = model.init(rng, dummy_x, update_stats=True, mutable=["params", "batch_stats"])

--- a/ml/HYBR/tests/test_convergence.py
+++ b/ml/HYBR/tests/test_convergence.py
@@ -26,7 +26,8 @@ def build_input(struct):
     rho = jnp.array(struct.density_field) / 7850.0
     rc = jnp.array(struct.rcomp_field) / 250.0
     rt = jnp.array(struct.rtens_field) / 500.0
-    return jnp.stack([occ, E, nu, rho, rc, rt], axis=-1)
+    anchor = jnp.array(struct.anchors, dtype=jnp.float32)
+    return jnp.stack([occ, E, nu, rho, rc, rt, anchor], axis=-1)
 
 
 def generate_dataset(n_samples, L, seed):
@@ -63,7 +64,7 @@ def test_convergence():
     )
 
     rng = jax.random.PRNGKey(42)
-    dummy = jnp.zeros((1, L, L, L, 6))
+    dummy = jnp.zeros((1, L, L, L, 7))
     variables = model.init(rng, dummy, update_stats=False, mutable=["params", "batch_stats"])
     params = variables["params"]
     batch_stats = variables.get("batch_stats", {})

--- a/ml/HYBR/tests/test_materialize.py
+++ b/ml/HYBR/tests/test_materialize.py
@@ -26,7 +26,7 @@ def test_materialize_matches_adaptive():
     )
 
     rng = jax.random.PRNGKey(7)
-    dummy_x = jnp.zeros((B, L, L, L, 6))
+    dummy_x = jnp.zeros((B, L, L, L, 7))
     variables = model.init(rng, dummy_x, update_stats=False, mutable=["params", "batch_stats"])
 
     # Random occupancy

--- a/ml/TRAINING.md
+++ b/ml/TRAINING.md
@@ -1,0 +1,177 @@
+# Block Reality ML — Training Guide
+
+## Quick Start (3 steps)
+
+```bash
+# 1. Setup (run once on GPU VM)
+bash ml/scripts/a100/setup_env.sh
+
+# 2. Smoke test (~5 min, validates full pipeline)
+bash ml/scripts/a100/launch.sh smoke
+
+# 3. Full training
+bash ml/scripts/a100/launch.sh brnext
+```
+
+## GCP VM Setup
+
+### Option A: V100 (development, ~$2.48/hr)
+
+```bash
+gcloud compute instances create br-train-v100 \
+  --zone=us-central1-a \
+  --machine-type=n1-standard-8 \
+  --accelerator=type=nvidia-tesla-v100,count=1 \
+  --image-family=pytorch-latest-gpu \
+  --image-project=deeplearning-platform-release \
+  --boot-disk-size=100GB \
+  --maintenance-policy=TERMINATE
+```
+
+### Option B: A100 (production, ~$3.67/hr)
+
+```bash
+gcloud compute instances create br-train-a100 \
+  --zone=us-central1-a \
+  --machine-type=a2-highgpu-1g \
+  --accelerator=type=nvidia-tesla-a100,count=1 \
+  --image-family=pytorch-latest-gpu \
+  --image-project=deeplearning-platform-release \
+  --boot-disk-size=200GB \
+  --maintenance-policy=TERMINATE
+```
+
+### After VM creation
+
+```bash
+# SSH into the VM
+gcloud compute ssh br-train-v100 --zone=us-central1-a
+
+# Clone the repo
+git clone <your-repo-url>
+cd Block-Realityapi-Fast-design
+
+# Run setup
+bash ml/scripts/a100/setup_env.sh
+```
+
+## Training Targets
+
+| Target | Command | GPU | Time | Grid | Output |
+|--------|---------|-----|------|------|--------|
+| Smoke test | `launch.sh smoke` | Any | ~5 min | 8^3 | Validates pipeline |
+| **BR-NeXT SSGO** | `launch.sh brnext` | A100 | ~3-4h | 16^3 | `bifrost_surrogate.onnx` |
+| HYBR Meta | `launch.sh hybr` | A100 | ~4-6h | 16^3 | `hybr_ssgo.onnx` |
+| Reborn Style | `launch.sh reborn` | A100 | ~3h | 16^3 | Style-conditioned model |
+| Benchmark | `launch.sh benchmark` | Any | ~2 min | 8^3 | Performance report |
+
+## Model Input/Output Contract
+
+All SSGO-family models follow this contract:
+
+```
+Input:  [B, L, L, L, 7]   7 channels:
+  ch0: occupancy         (1.0 = solid, 0.0 = air)
+  ch1: E / 200 GPa       (Young's modulus, normalized)
+  ch2: nu                (Poisson's ratio, raw)
+  ch3: rho / 7850        (density, normalized to steel)
+  ch4: rcomp / 250 MPa   (compression strength, normalized)
+  ch5: rtens / 500 MPa   (tension strength, normalized)
+  ch6: anchor            (1.0 = fixed support, 0.0 = free)
+
+Output: [B, L, L, L, 10]  10 channels:
+  ch0-5: stress tensor   (sigma_xx, yy, zz, tau_xy, yz, xz)
+  ch6-8: displacement    (u_x, u_y, u_z, log-transformed)
+  ch9:   phi             (PFSF-compatible potential field)
+```
+
+## Deploying Trained Models to Minecraft
+
+After training completes, copy the ONNX file to your Minecraft instance:
+
+```bash
+# The model file will be at:
+#   ml/experiments/outputs/brnext/a100_cmfd/brnext_ssgo.onnx
+# Or for robust trainer:
+#   ml/experiments/outputs/brnext/smoke_test/ssgo_robust_medium.onnx
+
+# Copy to Minecraft config directory:
+cp <onnx-file> <minecraft-root>/config/blockreality/models/bifrost_surrogate.onnx
+```
+
+The mod's `BIFROSTModelRegistry` will auto-detect and load the model on startup.
+
+### Available model slots
+
+| Filename | Purpose | Training source |
+|----------|---------|----------------|
+| `bifrost_surrogate.onnx` | Structural physics (stress+phi) | BR-NeXT / HYBR |
+| `bifrost_fluid.onnx` | Water simulation | brml fluid trainer |
+| `bifrost_lod.onnx` | LOD classification | brml LOD trainer |
+| `bifrost_collapse.onnx` | Collapse prediction | brml collapse trainer |
+
+## Advanced: Manual Training
+
+### BR-NeXT Robust SSGO (recommended)
+
+```bash
+source ml/.venv/bin/activate
+python -m brnext.train.train_robust_ssgo \
+    --grid 16 \
+    --steps-s1 5000 \
+    --steps-s2 5000 \
+    --steps-s3 10000 \
+    --batch-size 8 \
+    --lr 0.001 \
+    --hidden 48 \
+    --modes 8 \
+    --output ml/experiments/outputs/brnext/custom_run
+```
+
+### HYBR Meta-Trainer
+
+```bash
+python ml/scripts/a100/train_hybr_meta.py \
+    --config ml/configs/hybr_a100.yaml
+```
+
+### Training Stages (BR-NeXT)
+
+1. **Stage 1 — LEA Warm-up**: Low-fidelity alignment using material properties as pseudo-targets. Fast, builds basic input→output mapping.
+
+2. **Stage 2 — PFSF Distillation**: Distills phi field from CPU PFSF Jacobi solver. Teaches the model structural load flow patterns.
+
+3. **Stage 3 — FEM Fine-tuning**: Fine-tunes against full FEM solutions (stress + displacement + phi). Highest fidelity, most expensive per sample.
+
+## GPU Selection Guide
+
+| GPU | VRAM | Recommended for |
+|-----|------|----------------|
+| Tesla T4 | 16 GB | Inference only / minimal smoke tests |
+| **V100** | **16 GB** | **Development, debugging, small-scale training** |
+| V100 32GB | 32 GB | Larger batch sizes |
+| **A100 40GB** | **40 GB** | **Production training (best value)** |
+| A100 80GB | 80 GB | Config files target this; production training |
+| L4 | 24 GB | Good cost/performance for training |
+| H100 | 80 GB | Fastest, if budget allows |
+
+## Troubleshooting
+
+### JAX not using GPU
+
+```bash
+python -c "import jax; print(jax.default_backend())"
+# If output is "cpu", reinstall JAX:
+pip install "jax[cuda12]" --upgrade --force-reinstall
+```
+
+### Out of memory
+
+Reduce batch size or grid size:
+```bash
+python -m brnext.train.train_robust_ssgo --grid 8 --batch-size 2
+```
+
+### FEM solver slow (Stage 3)
+
+Stage 3 is CPU-bound (FEM ground truth generation). Increase `n_fem_workers` in config, or use a VM with more CPU cores.

--- a/ml/scripts/a100/launch.sh
+++ b/ml/scripts/a100/launch.sh
@@ -1,31 +1,84 @@
 #!/bin/bash
-# Master launcher for A100 training jobs
-# Usage: ./ml/scripts/a100/launch.sh [brnext|hybr|reborn]
-
+# ═══════════════════════════════════════════════════════════════
+# Block Reality ML — Training Launcher
+# Usage: bash ml/scripts/a100/launch.sh [brnext|hybr|reborn|smoke]
+# ═══════════════════════════════════════════════════════════════
 set -e
 
 TARGET=${1:-brnext}
 REPO_ROOT=$(cd "$(dirname "$0")/../../.." && pwd)
-export PYTHONPATH="$REPO_ROOT/ml/BR-NeXT:$REPO_ROOT/ml/HYBR:$REPO_ROOT/ml/brml:$REPO_ROOT/ml/reborn-ml/src:$PYTHONPATH"
 
+# Activate venv if exists
+if [ -f "$REPO_ROOT/ml/.venv/bin/activate" ]; then
+    source "$REPO_ROOT/ml/.venv/bin/activate"
+fi
+
+export PYTHONPATH="$REPO_ROOT/ml/BR-NeXT:$REPO_ROOT/ml/HYBR:$REPO_ROOT/ml/brml:$REPO_ROOT/ml/reborn-ml/src:$PYTHONPATH"
 cd "$REPO_ROOT"
 
+echo "═══════════════════════════════════════════════"
+echo " Block Reality ML — Training Launcher"
+echo " Target: $TARGET"
+echo " Time: $(date)"
+echo "═══════════════════════════════════════════════"
+
+# Show GPU info
+python3 -c "import jax; print(f'JAX backend: {jax.default_backend()}, devices: {len(jax.devices())}')" 2>/dev/null || true
+
 case $TARGET in
+  smoke)
+    echo ""
+    echo "Running smoke test (8³ grid, 100 steps each stage)..."
+    python3 -m brnext.train.train_robust_ssgo \
+        --grid 8 \
+        --steps-s1 100 --steps-s2 100 --steps-s3 200 \
+        --batch-size 2 \
+        --output ml/experiments/outputs/brnext/smoke_test
+    echo ""
+    echo "Smoke test complete! Check ml/experiments/outputs/brnext/smoke_test/"
+    ;;
   brnext)
+    echo ""
     echo "Launching BR-NeXT CMFD A100 training..."
-    python ml/scripts/a100/train_brnext_cmfd.py --config ml/configs/brnext_a100.yaml
+    python3 ml/scripts/a100/train_brnext_cmfd.py --config ml/configs/brnext_a100.yaml
+    echo ""
+    echo "Training complete. Models in: ml/experiments/outputs/brnext/a100_cmfd/"
+    echo ""
+    echo "To deploy: copy the .onnx file to your Minecraft instance:"
+    echo "  cp ml/experiments/outputs/brnext/a100_cmfd/brnext_ssgo.onnx \\"
+    echo "     <minecraft>/config/blockreality/models/bifrost_surrogate.onnx"
     ;;
   hybr)
+    echo ""
     echo "Launching HYBR Meta-Trainer A100 training..."
-    python ml/scripts/a100/train_hybr_meta.py --config ml/configs/hybr_a100.yaml
+    python3 ml/scripts/a100/train_hybr_meta.py --config ml/configs/hybr_a100.yaml
+    echo ""
+    echo "Training complete. Models in: ml/experiments/outputs/hybr/a100_meta/"
     ;;
   reborn)
+    echo ""
     echo "Launching Reborn Style Trainer A100 training..."
-    python ml/scripts/a100/train_reborn_style.py --config ml/configs/reborn_a100.yaml
+    python3 ml/scripts/a100/train_reborn_style.py --config ml/configs/reborn_a100.yaml
+    echo ""
+    echo "Training complete. Models in: ml/experiments/outputs/reborn/a100_style/"
+    ;;
+  benchmark)
+    echo ""
+    echo "Running A100 performance benchmark..."
+    python3 -m reborn.experiments.exp_008_a100_benchmark --grid 8
     ;;
   *)
     echo "Unknown target: $TARGET"
-    echo "Usage: $0 [brnext|hybr|reborn]"
+    echo ""
+    echo "Available targets:"
+    echo "  smoke     — Quick validation (8³, ~5 min on GPU)"
+    echo "  brnext    — Production SSGO training (16³, ~3-4h on A100)"
+    echo "  hybr      — HyperNetwork meta-learning (16³, ~4-6h on A100)"
+    echo "  reborn    — Style-conditioned training (16³, ~3h on A100)"
+    echo "  benchmark — GPU performance measurement"
     exit 1
     ;;
 esac
+
+echo ""
+echo "═══ Done at $(date) ═══"

--- a/ml/scripts/a100/setup_env.sh
+++ b/ml/scripts/a100/setup_env.sh
@@ -1,23 +1,110 @@
 #!/bin/bash
-# A100 environment setup for Block Reality ML stack
-# Run once on a fresh CUDA-enabled Linux node
-
+# ═══════════════════════════════════════════════════════════════
+# Block Reality ML — GPU Training Environment Setup
+# Compatible with: V100 / A100 / L4 / H100 on Google Cloud
+# ═══════════════════════════════════════════════════════════════
+#
+# Usage (from repo root):
+#   bash ml/scripts/a100/setup_env.sh
+#
+# Prerequisites:
+#   - NVIDIA driver installed (nvidia-smi should work)
+#   - CUDA 12.x toolkit
+#   - Python 3.10+
+#
 set -e
 
-echo "=== Installing core Python deps with CUDA 12 JAX ==="
-pip install -U pip
-pip install "jax[cuda12]>=0.4.20" jaxlib>=0.4.20 flax>=0.8.0 optax>=0.2.0
-pip install numpy>=1.24 scipy>=1.11 pyyaml>=6.0 zarr>=2.16 h5py>=3.9
-pip install onnx>=1.15 onnxruntime-gpu>=1.17 orbax-checkpoint>=0.4.0
+echo "═══════════════════════════════════════════════"
+echo " Block Reality ML — Environment Setup"
+echo "═══════════════════════════════════════════════"
 
-echo "=== Installing monorepo packages in editable mode ==="
-# Assumes run from repo root
+# ── 1. System check ──
+echo ""
+echo "--- System Check ---"
+python3 --version || { echo "ERROR: Python 3 not found"; exit 1; }
+nvidia-smi --query-gpu=name,memory.total --format=csv,noheader || { echo "WARNING: nvidia-smi failed, GPU may not be available"; }
+
+# ── 2. Create virtual environment ──
+VENV_DIR="ml/.venv"
+if [ ! -d "$VENV_DIR" ]; then
+    echo ""
+    echo "--- Creating virtual environment ---"
+    python3 -m venv "$VENV_DIR"
+fi
+source "$VENV_DIR/bin/activate"
+
+# ── 3. Core dependencies ──
+echo ""
+echo "--- Installing core dependencies ---"
+pip install -U pip setuptools wheel
+
+# JAX with CUDA 12 support (auto-detects GPU)
+pip install "jax[cuda12]>=0.4.20" "jaxlib>=0.4.20"
+
+# ML framework
+pip install "flax>=0.8.0" "optax>=0.2.0" "orbax-checkpoint>=0.4.0"
+
+# Numerics
+pip install "numpy>=1.24" "scipy>=1.11"
+
+# Data & config
+pip install "pyyaml>=6.0" "zarr>=2.16" "h5py>=3.9"
+
+# ONNX export & validation
+pip install "onnx>=1.15" "onnxruntime-gpu>=1.17"
+
+# Optional but useful
+pip install "tqdm>=4.66" "duckdb>=0.10" 2>/dev/null || true
+
+# ── 4. Install monorepo packages in editable mode ──
+echo ""
+echo "--- Installing BR ML packages (editable) ---"
 pip install -e ml/brml
 pip install -e ml/BR-NeXT
 pip install -e ml/HYBR
-pip install -e ml/reborn-ml
+pip install -e ml/reborn-ml 2>/dev/null || echo "  (reborn-ml skipped — optional)"
 
-echo "=== Verifying GPU visibility ==="
-python -c "import jax; print('JAX devices:', jax.devices()); print('JAX backend:', jax.default_backend())"
+# ── 5. Verify GPU ──
+echo ""
+echo "--- Verifying JAX GPU access ---"
+python3 -c "
+import jax
+devices = jax.devices()
+backend = jax.default_backend()
+print(f'  JAX backend: {backend}')
+print(f'  Devices ({len(devices)}):')
+for d in devices:
+    print(f'    {d}')
+if backend != 'gpu':
+    print('  WARNING: JAX is NOT using GPU! Training will be very slow.')
+    print('  Try: pip install jax[cuda12] --upgrade')
+"
 
-echo "=== A100 env ready ==="
+# ── 6. Quick smoke test ──
+echo ""
+echo "--- Smoke test: SSGO model init ---"
+python3 -c "
+import jax
+import jax.numpy as jnp
+from brnext.models.ssgo import SSGO
+model = SSGO(hidden=16, modes=4)
+rng = jax.random.PRNGKey(0)
+dummy = jnp.zeros((1, 4, 4, 4, 7))
+variables = model.init(rng, dummy)
+out = model.apply(variables, dummy)
+assert out.shape == (1, 4, 4, 4, 10), f'Unexpected shape: {out.shape}'
+print(f'  SSGO init OK — output shape: {out.shape}')
+print(f'  Params: {sum(p.size for p in jax.tree_util.tree_leaves(variables[\"params\"])):,}')
+"
+
+echo ""
+echo "═══════════════════════════════════════════════"
+echo " Setup complete! Ready to train."
+echo ""
+echo " Quick start:"
+echo "   bash ml/scripts/a100/launch.sh brnext"
+echo ""
+echo " Or manual:"
+echo "   source ml/.venv/bin/activate"
+echo "   python -m brnext.train.train_robust_ssgo --grid 8"
+echo "═══════════════════════════════════════════════"


### PR DESCRIPTION
訓練端 (train_robust_ssgo.py) 使用 7 通道輸入（含 anchor），但 Java 推理端
(OnnxPFSFRuntime) 和 ONNX 合約驗證僅使用 6 通道，導致匯出的模型無法正確推理。

修復內容：
- OnnxPFSFRuntime.java: 加入 anchor 通道（使用已存在的 anchorLookup）
- BIFROSTModelRegistry: surrogate inputChannels 6→7
- contract_adapter.py: 合約驗證更新為 7ch
- onnx_export.py / manual_onnx.py: 匯出 dummy 更新為 7ch
- cmfd_trainer.py: _build_input 加入 anchor，init/export dummy 更新為 7ch
- train_robust_ssgo.py: _export dummy 包裝為 tuple（修復 jax2onnx 迭代問題）
- HYBR meta_trainer / materialize / train_hybr: 統一更新為 7ch
- 所有相關測試更新為 7ch

訓練包改善：
- setup_env.sh: 完整 GPU 環境設定（含 venv、smoke test、GPU 驗證）
- launch.sh: 新增 smoke/benchmark 目標，自動啟用 venv
- TRAINING.md: 完整訓練指南（GCP VM 建立、部署步驟）

https://claude.ai/code/session_016BS7WqTpohK7rtRjncomCG