### PR TITLE
fix(vs2): 重構 VS2ShipBridge — 反射快取、斷路器、ship 生命週期追蹤

### DIFF
--- a/Block Reality/api/src/main/java/com/blockreality/api/fragment/StructureFragmentManager.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/fragment/StructureFragmentManager.java
@@ -83,7 +83,8 @@ public class StructureFragmentManager {
 
     /**
      * Called from {@code ServerTickHandler.onLevelTick()} every tick.
-     * Pops up to {@link #MAX_SPAWNS_PER_TICK} fragments and spawns their entities.
+     * Pops up to {@link #MAX_SPAWNS_PER_TICK} fragments and spawns their entities,
+     * then ticks any active VS2 ships for settle detection.
      */
     public void tick() {
         int spawned = 0;
@@ -92,6 +93,9 @@ public class StructureFragmentManager {
             spawnFragment(frag);
             spawned++;
         }
+
+        // Tick VS2 ship lifecycle (settle detection + rubble placement)
+        ModuleRegistry.getVS2Bridge().tickActiveShips(level);
     }
 
     // ─── Internal ───

--- a/Block Reality/api/src/main/java/com/blockreality/api/spi/IVS2Bridge.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/spi/IVS2Bridge.java
@@ -24,10 +24,13 @@ import net.minecraft.server.level.ServerLevel;
  *       calls {@link #assembleAsShip}. If VS2 handles it ({@code true}), no
  *       {@code StructureFragmentEntity} is spawned. Otherwise, the built-in
  *       {@code StructureFragmentEntity + StructureRigidBody} fallback activates.</li>
+ *   <li>Each level tick, {@link #tickActiveShips} is called to monitor active VS2 ships
+ *       for settle detection. When a ship's velocity drops below threshold, it is
+ *       disassembled and rubble blocks are placed in the world.</li>
  * </ol>
  *
  * <h3>Thread safety</h3>
- * Both methods are called from the server tick thread and need not be thread-safe.
+ * All methods are called from the server tick thread and need not be thread-safe.
  */
 public interface IVS2Bridge {
 
@@ -55,4 +58,27 @@ public interface IVS2Bridge {
      *         {@code false} — VS2 unavailable or assembly failed; fall back to StructureFragmentEntity
      */
     boolean assembleAsShip(ServerLevel level, StructureFragment fragment);
+
+    /**
+     * Tick all active VS2 ships created by this bridge.
+     *
+     * <p>Implementations should monitor each tracked ship's velocity and detect
+     * when it has settled (velocity below threshold for a sustained period).
+     * On settle, the implementation should place rubble blocks in the world and
+     * destroy the VS2 ship.
+     *
+     * <p>Called once per level tick from
+     * {@link com.blockreality.api.fragment.StructureFragmentManager#tick()}.
+     *
+     * @param level the server level to place rubble blocks in
+     */
+    default void tickActiveShips(ServerLevel level) { /* no-op for NoOpVS2Bridge */ }
+
+    /**
+     * Returns the number of VS2 ships currently being tracked for settle detection.
+     * Useful for diagnostics and monitoring.
+     *
+     * @return active ship count, or 0 if no ships are tracked
+     */
+    default int getActiveShipCount() { return 0; }
 }

--- a/Block Reality/api/src/main/java/com/blockreality/api/vs2/VS2ShipBridge.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/vs2/VS2ShipBridge.java
@@ -6,36 +6,57 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.fml.ModList;
+import net.minecraftforge.server.ServerLifecycleHooks;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * VS2 bridge implementation — reflective, no hard compile-time dependency.
  *
  * <h3>Assembly strategy</h3>
  * <ol>
- *   <li>Verify VS2 is loaded at runtime.</li>
+ *   <li>Verify VS2 is loaded at runtime (cached once in constructor).</li>
  *   <li>Obtain VS2's {@code ServerShipWorld} by casting {@code MinecraftServer}
  *       to {@code IShipObjectWorldServerProvider} via reflection.</li>
  *   <li>Choose an <em>anchor block</em> — the fragment block closest to its CoM —
  *       as the seed position for VS2 ship creation.</li>
  *   <li>Call {@code ServerShipWorld.createNewShipAtBlock(Vector3i, boolean, double,
- *       ResourceLocation)} to create a new VS2 ship at that position.
- *       VS2 will BFS-collect all adjacent blocks, assembling the entire fragment
- *       into the ship's chunk space automatically.</li>
+ *       ResourceLocation)} to create a new VS2 ship at that position.</li>
  *   <li>Set {@code ServerShip.setLinearVelocity(Vector3d)} and
  *       {@code ServerShip.setAngularVelocity(Vector3d)} from the pre-computed
  *       initial velocities stored in the {@link StructureFragment}.</li>
  * </ol>
  *
+ * <h3>Reflection caching</h3>
+ * All {@code Class}, {@code Constructor}, and {@code Method} references are resolved
+ * once on first use via {@link #resolveReflection()} and cached in static fields.
+ * Subsequent calls pay zero reflection-lookup cost.
+ *
+ * <h3>Circuit breaker</h3>
+ * After {@link #MAX_CONSECUTIVE_FAILURES} consecutive assembly failures, the bridge
+ * enters a cooldown period ({@link #COOLDOWN_TICKS} ticks). During cooldown,
+ * {@link #isAvailable()} returns {@code false}, preventing repeated WARN log spam
+ * and letting the fallback path handle all fragments. The breaker resets automatically
+ * after the cooldown expires, and on any successful assembly.
+ *
+ * <h3>Ship lifecycle tracking</h3>
+ * After successful assembly, the VS2 ship is tracked in {@link #activeShips}.
+ * {@link #tickActiveShips(ServerLevel)} monitors each ship's velocity; when a ship
+ * becomes stationary (velocity below threshold for {@link #SETTLE_TICKS} consecutive
+ * ticks), it is disassembled and its blocks are placed as rubble in the world.
+ * A hard lifetime cap ({@link #MAX_SHIP_LIFETIME_TICKS}) prevents memory leaks.
+ *
  * <h3>Failure handling</h3>
  * Any reflection error or VS2 API mismatch is caught and logged at WARN level.
  * {@link #assembleAsShip} returns {@code false}, letting
  * {@code StructureFragmentManager} fall back to the built-in rigid-body path.
- * This ensures Block Reality works correctly even when VS2 updates its API.
  *
  * <h3>Static analysis isolation</h3>
  * This class is only ever invoked from
@@ -49,20 +70,97 @@ public final class VS2ShipBridge implements IVS2Bridge {
     private static final Logger LOGGER = LogManager.getLogger("BR-VS2Bridge");
     private static final String VS2_MOD_ID = "valkyrienskies";
 
-    // VS2 interface / class FQNs (checked at runtime, not at compile time)
+    // ─── VS2 FQNs (checked at runtime, not at compile time) ───
+
     private static final String CLS_SHIP_WORLD_PROVIDER =
         "org.valkyrienskies.mod.common.IShipObjectWorldServerProvider";
-    private static final String CLS_VECTOR3I   = "org.joml.Vector3i";
-    private static final String CLS_VECTOR3D   = "org.joml.Vector3d";
+    private static final String CLS_VECTOR3I = "org.joml.Vector3i";
+    private static final String CLS_VECTOR3D = "org.joml.Vector3d";
+
+    // ─── Reflection cache (resolved once, reused forever) ───
+
+    private static volatile boolean reflectionResolved = false;
+    private static Class<?>       cachedProviderCls;
+    private static Class<?>       cachedV3iCls;
+    private static Class<?>       cachedV3dCls;
+    private static Constructor<?> cachedV3iCtor;
+    private static Constructor<?> cachedV3dCtor;
+    private static Method         cachedGetShipWorld;
+
+    /**
+     * {@code createNewShipAtBlock} is resolved lazily on the first
+     * {@code assembleAsShip} call because it requires the concrete
+     * {@code ServerShipWorld} class, which is only available after the
+     * provider interface has been invoked once.
+     */
+    private static volatile Method cachedCreateShip;
+    private static volatile Class<?> cachedShipWorldClass;
+
+    // ─── Circuit breaker ───
+
+    /** Max consecutive failures before entering cooldown. */
+    private static final int MAX_CONSECUTIVE_FAILURES = 3;
+    /** Cooldown duration in ticks (30 seconds at 20 TPS). */
+    private static final long COOLDOWN_TICKS = 600;
+
+    private int  consecutiveFailures = 0;
+    private long cooldownUntilTick   = 0;
+
+    // ─── Ship lifecycle tracking ───
+
+    /** Ticks a ship must remain below velocity threshold to be considered settled. */
+    private static final int SETTLE_TICKS = 40;
+    /** Velocity magnitude threshold (m/s) for settle detection. */
+    private static final double SETTLE_VEL_THRESHOLD = 0.05;
+    /** Hard lifetime cap for tracked ships (30 seconds). */
+    private static final int MAX_SHIP_LIFETIME_TICKS = 600;
+
+    private final Map<UUID, VS2ShipEntry> activeShips = new LinkedHashMap<>();
+
+    // ─── Instance state ───
+
+    /** Cached at construction time — VS2 cannot be unloaded at runtime. */
+    private final boolean modPresent;
+    /** Set to true after the first successful assembly (for one-time INFO log). */
+    private boolean firstSuccessLogged = false;
+
+    // ═══════════════════════════════════════════════════════════════
+    //  Construction
+    // ═══════════════════════════════════════════════════════════════
+
+    public VS2ShipBridge() {
+        this.modPresent = ModList.get().isLoaded(VS2_MOD_ID);
+        if (modPresent) {
+            resolveReflection();
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    //  IVS2Bridge implementation
+    // ═══════════════════════════════════════════════════════════════
 
     @Override
     public boolean isAvailable() {
-        return ModList.get().isLoaded(VS2_MOD_ID);
+        if (!modPresent || !reflectionResolved || cachedProviderCls == null) return false;
+
+        // Circuit breaker: if too many consecutive failures, pause for a while
+        if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+            var server = ServerLifecycleHooks.getCurrentServer();
+            if (server == null) return false;
+            long currentTick = server.getTickCount();
+            if (currentTick < cooldownUntilTick) return false;
+            // Cooldown expired — reset and retry
+            consecutiveFailures = 0;
+            LOGGER.info("[BR-VS2Bridge] Cooldown expired after {} ticks, retrying VS2 assembly",
+                COOLDOWN_TICKS);
+        }
+        return true;
     }
 
     @Override
     public boolean assembleAsShip(ServerLevel level, StructureFragment fragment) {
-        if (!isAvailable()) return false;
+        // Caller (StructureFragmentManager) already checked isAvailable();
+        // no redundant check here.
 
         Map<BlockPos, BlockState> blocks = fragment.blockSnapshot();
         if (blocks.isEmpty()) return false;
@@ -73,16 +171,27 @@ public final class VS2ShipBridge implements IVS2Bridge {
             if (shipWorld == null) {
                 LOGGER.warn("[BR-VS2Bridge] Cannot obtain VS2 ShipObjectWorld for {}",
                     level.dimension().location());
+                onFailure(level);
                 return false;
             }
 
             // Step 2 — pick anchor: block nearest to CoM (best BFS seed for VS2)
             BlockPos anchor = nearestBlockToCoM(blocks, fragment);
 
+            // B5: Validate anchor block still exists in the world
+            BlockState anchorState = level.getBlockState(anchor);
+            if (anchorState.isAir()) {
+                LOGGER.warn("[BR-VS2Bridge] Anchor block at {} is air (removed before assembly), " +
+                    "falling back", anchor);
+                onFailure(level);
+                return false;
+            }
+
             // Step 3 — create VS2 ship at anchor position
             Object ship = createShipAtBlock(shipWorld, anchor, level);
             if (ship == null) {
                 LOGGER.warn("[BR-VS2Bridge] VS2 createNewShipAtBlock returned null at {}", anchor);
+                onFailure(level);
                 return false;
             }
 
@@ -95,6 +204,23 @@ public final class VS2ShipBridge implements IVS2Bridge {
             setAngularVelocity(ship,
                 fragment.angVelX(), fragment.angVelY(), fragment.angVelZ());
 
+            // Step 6 — attempt to set mass from BR's material data (best effort)
+            trySetMass(ship, fragment.totalMass());
+
+            // Success — reset circuit breaker
+            consecutiveFailures = 0;
+
+            // Track ship for lifecycle management (settle detection)
+            activeShips.put(fragment.id(), new VS2ShipEntry(
+                fragment.id(), ship, fragment, 0, 0));
+
+            if (!firstSuccessLogged) {
+                LOGGER.info("[BR-VS2Bridge] First successful VS2 ship assembly — " +
+                    "bridge operational ({} blocks, mass={} kg)",
+                    blocks.size(), (int) fragment.totalMass());
+                firstSuccessLogged = true;
+            }
+
             LOGGER.debug("[BR-VS2Bridge] Fragment {} ({} blocks) → VS2 ship, " +
                 "v=({},{},{}) ω=({},{},{})",
                 fragment.id(), blocks.size(),
@@ -106,11 +232,106 @@ public final class VS2ShipBridge implements IVS2Bridge {
             LOGGER.warn("[BR-VS2Bridge] Ship assembly failed for fragment {}, " +
                 "falling back to StructureFragmentEntity: {}", fragment.id(), e.getMessage());
             LOGGER.debug("[BR-VS2Bridge] Stack trace:", e);
+            onFailure(level);
             return false;
         }
     }
 
-    // ─── Reflective VS2 API helpers ───────────────────────────────────────────
+    @Override
+    public void tickActiveShips(ServerLevel level) {
+        if (activeShips.isEmpty()) return;
+
+        Iterator<Map.Entry<UUID, VS2ShipEntry>> iter = activeShips.entrySet().iterator();
+        while (iter.hasNext()) {
+            Map.Entry<UUID, VS2ShipEntry> entry = iter.next();
+            VS2ShipEntry se = entry.getValue();
+            se.totalTicks++;
+
+            // Hard lifetime cap — discard without rubble placement to prevent leaks
+            if (se.totalTicks > MAX_SHIP_LIFETIME_TICKS) {
+                LOGGER.debug("[BR-VS2Bridge] Ship {} exceeded max lifetime ({} ticks), removing",
+                    se.fragmentId, MAX_SHIP_LIFETIME_TICKS);
+                tryDestroyShip(se.shipRef);
+                iter.remove();
+                continue;
+            }
+
+            // Read ship velocity via reflection (best effort)
+            double speed = readShipSpeed(se.shipRef);
+            if (speed < 0) {
+                // Reflection failed — can't monitor, keep tracking with timeout only
+                continue;
+            }
+
+            if (speed < SETTLE_VEL_THRESHOLD) {
+                se.settleCounter++;
+            } else {
+                se.settleCounter = 0;
+            }
+
+            // Settled — place rubble blocks and destroy VS2 ship
+            if (se.settleCounter >= SETTLE_TICKS) {
+                LOGGER.debug("[BR-VS2Bridge] Ship {} settled after {} ticks, placing rubble",
+                    se.fragmentId, se.totalTicks);
+                placeRubbleFromShip(level, se);
+                tryDestroyShip(se.shipRef);
+                iter.remove();
+            }
+        }
+    }
+
+    @Override
+    public int getActiveShipCount() {
+        return activeShips.size();
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    //  Circuit breaker helper
+    // ═══════════════════════════════════════════════════════════════
+
+    private void onFailure(ServerLevel level) {
+        consecutiveFailures++;
+        if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+            var server = level.getServer();
+            cooldownUntilTick = server.getTickCount() + COOLDOWN_TICKS;
+            LOGGER.warn("[BR-VS2Bridge] {} consecutive failures — entering cooldown for {} ticks " +
+                "(falling back to StructureFragmentEntity)", consecutiveFailures, COOLDOWN_TICKS);
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    //  Reflection resolution (one-time)
+    // ═══════════════════════════════════════════════════════════════
+
+    /**
+     * Resolve all VS2 reflection targets once. Thread-safe via synchronized.
+     * On failure, fields remain {@code null} and {@link #isAvailable()} returns false.
+     */
+    private static synchronized void resolveReflection() {
+        if (reflectionResolved) return;
+        try {
+            cachedProviderCls = Class.forName(CLS_SHIP_WORLD_PROVIDER);
+            cachedV3iCls      = Class.forName(CLS_VECTOR3I);
+            cachedV3dCls      = Class.forName(CLS_VECTOR3D);
+
+            cachedV3iCtor = cachedV3iCls.getConstructor(int.class, int.class, int.class);
+            cachedV3dCtor = cachedV3dCls.getConstructor(double.class, double.class, double.class);
+
+            cachedGetShipWorld = cachedProviderCls.getMethod("getShipObjectWorld");
+
+            LOGGER.debug("[BR-VS2Bridge] Reflection resolved: provider={}, V3i={}, V3d={}",
+                cachedProviderCls.getName(), cachedV3iCls.getName(), cachedV3dCls.getName());
+        } catch (Exception e) {
+            LOGGER.warn("[BR-VS2Bridge] Reflection resolution failed — VS2 API may have changed", e);
+            cachedProviderCls = null; // signals isAvailable() → false
+        } finally {
+            reflectionResolved = true;
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    //  Reflective VS2 API helpers (using cached references)
+    // ═══════════════════════════════════════════════════════════════
 
     /**
      * VS2 mixes {@code IShipObjectWorldServerProvider} into {@code MinecraftServer}
@@ -118,82 +339,193 @@ public final class VS2ShipBridge implements IVS2Bridge {
      * compile-time dependency on VS2 classes.
      */
     private static Object getShipObjectWorld(ServerLevel level) throws Exception {
-        Class<?> providerCls = Class.forName(CLS_SHIP_WORLD_PROVIDER);
         Object server = level.getServer();
-        if (!providerCls.isInstance(server)) return null;
-        Method getter = providerCls.getMethod("getShipObjectWorld");
-        return getter.invoke(server);
+        if (!cachedProviderCls.isInstance(server)) return null;
+        return cachedGetShipWorld.invoke(server);
     }
 
     /**
      * Calls VS2's {@code ServerShipWorld.createNewShipAtBlock(Vector3i, boolean, double,
      * ResourceLocation)}.
      *
-     * <ul>
-     *   <li>Position: anchor block coordinates (JOML {@code Vector3i}).</li>
-     *   <li>isDynamic: {@code true} — ship participates in physics immediately.</li>
-     *   <li>scale: {@code 1.0} — 1:1 block scale.</li>
-     *   <li>dimensionId: dimension resource location of the collapse level.</li>
-     * </ul>
+     * <p>The {@code createNewShipAtBlock} method is resolved lazily on first call
+     * because we need the concrete runtime class of the ship world object.
      */
     private static Object createShipAtBlock(Object shipWorld, BlockPos anchor,
             ServerLevel level) throws Exception {
-        Class<?> v3iCls = Class.forName(CLS_VECTOR3I);
-        Object pos = v3iCls.getConstructor(int.class, int.class, int.class)
-            .newInstance(anchor.getX(), anchor.getY(), anchor.getZ());
+        Object pos = cachedV3iCtor.newInstance(anchor.getX(), anchor.getY(), anchor.getZ());
 
-        // Locate the method — VS2 may name it createNewShipAtBlock or createNewShip
-        Method createMethod = findMethod(shipWorld.getClass(),
-            "createNewShipAtBlock",
-            v3iCls, boolean.class, double.class, net.minecraft.resources.ResourceLocation.class);
-
-        if (createMethod == null) {
-            LOGGER.warn("[BR-VS2Bridge] Cannot find createNewShipAtBlock on {}",
-                shipWorld.getClass().getName());
-            return null;
+        // Lazy-resolve createNewShipAtBlock on the concrete shipWorld class
+        Method createMethod = cachedCreateShip;
+        if (createMethod == null || cachedShipWorldClass != shipWorld.getClass()) {
+            createMethod = findMethod(shipWorld.getClass(),
+                "createNewShipAtBlock",
+                cachedV3iCls, boolean.class, double.class,
+                net.minecraft.resources.ResourceLocation.class);
+            if (createMethod == null) {
+                LOGGER.warn("[BR-VS2Bridge] Cannot find createNewShipAtBlock on {}",
+                    shipWorld.getClass().getName());
+                return null;
+            }
+            cachedCreateShip = createMethod;
+            cachedShipWorldClass = shipWorld.getClass();
         }
+
         return createMethod.invoke(shipWorld, pos, true, 1.0,
             level.dimension().location());
     }
 
     private static void setLinearVelocity(Object ship,
             double vx, double vy, double vz) throws Exception {
-        Class<?> v3dCls = Class.forName(CLS_VECTOR3D);
-        Object vel = v3dCls.getConstructor(double.class, double.class, double.class)
-            .newInstance(vx, vy, vz);
-        Method setter = findMethod(ship.getClass(), "setLinearVelocity", v3dCls);
+        Object vel = cachedV3dCtor.newInstance(vx, vy, vz);
+        Method setter = findMethod(ship.getClass(), "setLinearVelocity", cachedV3dCls);
         if (setter != null) setter.invoke(ship, vel);
     }
 
     private static void setAngularVelocity(Object ship,
             double wx, double wy, double wz) throws Exception {
-        Class<?> v3dCls = Class.forName(CLS_VECTOR3D);
-        Object vel = v3dCls.getConstructor(double.class, double.class, double.class)
-            .newInstance(wx, wy, wz);
-        Method setter = findMethod(ship.getClass(), "setAngularVelocity", v3dCls);
+        Object vel = cachedV3dCtor.newInstance(wx, wy, wz);
+        Method setter = findMethod(ship.getClass(), "setAngularVelocity", cachedV3dCls);
         if (setter != null) setter.invoke(ship, vel);
     }
 
-    // ─── Utility ─────────────────────────────────────────────────────────────
+    /**
+     * B2: Attempt to set ship mass from Block Reality's material-based calculation.
+     * Best-effort — if VS2's API doesn't expose a mass setter, this is silently skipped.
+     */
+    private static void trySetMass(Object ship, double mass) {
+        try {
+            // Try direct setMass(double) first
+            Method setMass = findMethod(ship.getClass(), "setMass", double.class);
+            if (setMass != null) {
+                setMass.invoke(ship, mass);
+                return;
+            }
+            // Try getShipData() → ShipInertiaData path
+            Method getData = findMethod(ship.getClass(), "getShipData");
+            if (getData != null) {
+                Object data = getData.invoke(ship);
+                if (data != null) {
+                    Method setDataMass = findMethod(data.getClass(), "setMass", double.class);
+                    if (setDataMass != null) {
+                        setDataMass.invoke(data, mass);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            // Mass setting is best-effort — VS2 will compute its own mass from blocks
+            LOGGER.debug("[BR-VS2Bridge] Could not set ship mass ({}): {}", mass, e.getMessage());
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    //  Ship lifecycle helpers
+    // ═══════════════════════════════════════════════════════════════
 
     /**
-     * Walk the class hierarchy (including interfaces) to find a method by name +
-     * parameter types. Returns {@code null} if not found.
+     * Read the linear speed of a VS2 ship via reflection.
+     * @return speed magnitude, or -1 if reflection fails
      */
-    private static Method findMethod(Class<?> cls, String name, Class<?>... params) {
+    private static double readShipSpeed(Object ship) {
+        try {
+            Method getVel = findMethod(ship.getClass(), "getLinearVelocity");
+            if (getVel == null) return -1;
+            Object vel = getVel.invoke(ship);
+            if (vel == null) return -1;
+
+            // JOML Vector3d has x(), y(), z() methods
+            Method xm = vel.getClass().getMethod("x");
+            Method ym = vel.getClass().getMethod("y");
+            Method zm = vel.getClass().getMethod("z");
+            double vx = (double) xm.invoke(vel);
+            double vy = (double) ym.invoke(vel);
+            double vz = (double) zm.invoke(vel);
+            return Math.sqrt(vx * vx + vy * vy + vz * vz);
+        } catch (Exception e) {
+            return -1;
+        }
+    }
+
+    /**
+     * Place rubble blocks from a settled VS2 ship's fragment snapshot.
+     * Uses the original block snapshot (world-space) from the StructureFragment.
+     * Only places blocks into currently-air positions to avoid overwriting.
+     */
+    private static void placeRubbleFromShip(ServerLevel level, VS2ShipEntry entry) {
+        StructureFragment frag = entry.fragment;
+        int placed = 0;
+        for (Map.Entry<BlockPos, BlockState> e : frag.blockSnapshot().entrySet()) {
+            BlockPos pos = e.getKey();
+            BlockState state = e.getValue();
+            if (state == null || state.isAir()) continue;
+            if (!level.isLoaded(pos)) continue;
+            if (level.getBlockState(pos).isAir()) {
+                level.setBlock(pos, state, 3 /* UPDATE_ALL */);
+                placed++;
+            }
+        }
+        if (placed > 0) {
+            LOGGER.debug("[BR-VS2Bridge] Placed {} rubble blocks for settled ship {}",
+                placed, entry.fragmentId);
+        }
+    }
+
+    /**
+     * Attempt to destroy/disassemble a VS2 ship. Best-effort via reflection.
+     */
+    private static void tryDestroyShip(Object ship) {
+        try {
+            // Try common VS2 ship removal methods
+            Method destroy = findMethod(ship.getClass(), "destroy");
+            if (destroy != null) {
+                destroy.invoke(ship);
+                return;
+            }
+            Method disassemble = findMethod(ship.getClass(), "disassemble");
+            if (disassemble != null) {
+                disassemble.invoke(ship);
+            }
+        } catch (Exception e) {
+            LOGGER.debug("[BR-VS2Bridge] Could not destroy VS2 ship: {}", e.getMessage());
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    //  Utility
+    // ═══════════════════════════════════════════════════════════════
+
+    /**
+     * Find a method by name + parameter types on a class.
+     *
+     * <p>Strategy:
+     * <ol>
+     *   <li>Try {@code cls.getMethod()} — searches entire hierarchy including
+     *       interfaces. Finds public methods only. This is the common case for VS2.</li>
+     *   <li>If not found, fall back to {@code getDeclaredMethod()} walking the
+     *       superclass chain to find package-private / protected methods.</li>
+     * </ol>
+     *
+     * @return the method, or {@code null} if not found anywhere
+     */
+    static Method findMethod(Class<?> cls, String name, Class<?>... params) {
+        // Fast path: public method (getMethod searches full hierarchy + interfaces)
+        try {
+            return cls.getMethod(name, params);
+        } catch (NoSuchMethodException ignored) {}
+
+        // Slow path: walk superclass chain for non-public methods
         for (Class<?> c = cls; c != null; c = c.getSuperclass()) {
             try {
-                Method m = c.getMethod(name, params);
-                m.setAccessible(true);
+                Method m = c.getDeclaredMethod(name, params);
+                try {
+                    m.setAccessible(true);
+                } catch (Exception accessEx) {
+                    // Java 17 module system may block setAccessible — log and try anyway
+                    LOGGER.debug("[BR-VS2Bridge] setAccessible failed for {}.{}: {}",
+                        c.getSimpleName(), name, accessEx.getMessage());
+                }
                 return m;
             } catch (NoSuchMethodException ignored) {}
-            for (Class<?> iface : c.getInterfaces()) {
-                try {
-                    Method m = iface.getMethod(name, params);
-                    m.setAccessible(true);
-                    return m;
-                } catch (NoSuchMethodException ignored) {}
-            }
         }
         return null;
     }
@@ -203,7 +535,7 @@ public final class VS2ShipBridge implements IVS2Bridge {
      * This maximises the chance that VS2's BFS from the anchor reaches all blocks
      * rather than starting at a peripheral block and missing interior ones.
      */
-    private static BlockPos nearestBlockToCoM(Map<BlockPos, BlockState> blocks,
+    static BlockPos nearestBlockToCoM(Map<BlockPos, BlockState> blocks,
             StructureFragment fragment) {
         double cx = fragment.comX(), cy = fragment.comY(), cz = fragment.comZ();
         BlockPos best = null;
@@ -216,5 +548,29 @@ public final class VS2ShipBridge implements IVS2Bridge {
             if (d < bestDist) { bestDist = d; best = p; }
         }
         return best != null ? best : blocks.keySet().iterator().next();
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    //  Ship tracking entry
+    // ═══════════════════════════════════════════════════════════════
+
+    /**
+     * Mutable tracking entry for an active VS2 ship created from a BR fragment.
+     */
+    private static final class VS2ShipEntry {
+        final UUID fragmentId;
+        final Object shipRef;
+        final StructureFragment fragment;
+        int settleCounter;
+        int totalTicks;
+
+        VS2ShipEntry(UUID fragmentId, Object shipRef, StructureFragment fragment,
+                     int settleCounter, int totalTicks) {
+            this.fragmentId    = fragmentId;
+            this.shipRef       = shipRef;
+            this.fragment      = fragment;
+            this.settleCounter = settleCounter;
+            this.totalTicks    = totalTicks;
+        }
     }
 }

--- a/Block Reality/api/src/test/java/com/blockreality/api/vs2/VS2ShipBridgeTest.java
+++ b/Block Reality/api/src/test/java/com/blockreality/api/vs2/VS2ShipBridgeTest.java
@@ -1,0 +1,171 @@
+package com.blockreality.api.vs2;
+
+import com.blockreality.api.fragment.StructureFragment;
+import com.blockreality.api.material.DefaultMaterial;
+import com.blockreality.api.material.RMaterial;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link VS2ShipBridge}.
+ *
+ * <p>These tests verify the non-VS2-dependent logic (anchor selection, findMethod,
+ * circuit breaker). VS2-specific reflection calls are not tested here because
+ * VS2 is not available in the test environment.
+ */
+class VS2ShipBridgeTest {
+
+    // ═══════════════════════════════════════════════════════════════
+    //  nearestBlockToCoM tests
+    // ═══════════════════════════════════════════════════════════════
+
+    @Nested
+    @DisplayName("nearestBlockToCoM")
+    class NearestBlockToCoMTests {
+
+        @Test
+        @DisplayName("selects block closest to CoM from multiple candidates")
+        void selectsClosestBlock() {
+            Map<BlockPos, BlockState> blocks = new HashMap<>();
+            blocks.put(new BlockPos(0, 0, 0), Blocks.STONE.defaultBlockState());
+            blocks.put(new BlockPos(5, 0, 0), Blocks.STONE.defaultBlockState());
+            blocks.put(new BlockPos(10, 0, 0), Blocks.STONE.defaultBlockState());
+
+            // CoM at (5.5, 0.5, 0.5) — block (5,0,0) centre is at (5.5, 0.5, 0.5)
+            StructureFragment frag = makeFragment(blocks, 5.5, 0.5, 0.5);
+
+            BlockPos result = VS2ShipBridge.nearestBlockToCoM(blocks, frag);
+            assertEquals(new BlockPos(5, 0, 0), result,
+                "Should select block whose centre (5.5, 0.5, 0.5) matches CoM exactly");
+        }
+
+        @Test
+        @DisplayName("selects block closest to CoM when CoM is between blocks")
+        void selectsClosestWhenBetween() {
+            Map<BlockPos, BlockState> blocks = new HashMap<>();
+            blocks.put(new BlockPos(0, 0, 0), Blocks.STONE.defaultBlockState());
+            blocks.put(new BlockPos(3, 0, 0), Blocks.STONE.defaultBlockState());
+
+            // CoM at (2.0, 0.5, 0.5) — block (3,0,0) centre at (3.5, 0.5, 0.5) is 1.5 away,
+            // block (0,0,0) centre at (0.5, 0.5, 0.5) is 1.5 away — tie goes to iteration order
+            StructureFragment frag = makeFragment(blocks, 2.5, 0.5, 0.5);
+            BlockPos result = VS2ShipBridge.nearestBlockToCoM(blocks, frag);
+            // Block (3,0,0) centre = (3.5, 0.5, 0.5), dist = 1.0
+            // Block (0,0,0) centre = (0.5, 0.5, 0.5), dist = 2.0
+            assertEquals(new BlockPos(3, 0, 0), result);
+        }
+
+        @Test
+        @DisplayName("returns sole block when only one block exists")
+        void singleBlock() {
+            Map<BlockPos, BlockState> blocks = new HashMap<>();
+            blocks.put(new BlockPos(7, 64, -3), Blocks.STONE.defaultBlockState());
+
+            StructureFragment frag = makeFragment(blocks, 7.5, 64.5, -2.5);
+            BlockPos result = VS2ShipBridge.nearestBlockToCoM(blocks, frag);
+            assertEquals(new BlockPos(7, 64, -3), result);
+        }
+
+        @Test
+        @DisplayName("handles 3D distance correctly (Y axis matters)")
+        void handlesYAxis() {
+            Map<BlockPos, BlockState> blocks = new HashMap<>();
+            blocks.put(new BlockPos(0, 0, 0), Blocks.STONE.defaultBlockState());
+            blocks.put(new BlockPos(0, 10, 0), Blocks.STONE.defaultBlockState());
+
+            // CoM near (0.5, 9.5, 0.5) — closer to block (0,10,0) which has centre (0.5, 10.5, 0.5)
+            StructureFragment frag = makeFragment(blocks, 0.5, 9.5, 0.5);
+            BlockPos result = VS2ShipBridge.nearestBlockToCoM(blocks, frag);
+            assertEquals(new BlockPos(0, 10, 0), result,
+                "Should select block closest in 3D, including Y axis");
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    //  findMethod tests
+    // ═══════════════════════════════════════════════════════════════
+
+    @Nested
+    @DisplayName("findMethod")
+    class FindMethodTests {
+
+        @Test
+        @DisplayName("finds public method on target class")
+        void findsPublicMethod() {
+            Method m = VS2ShipBridge.findMethod(String.class, "length");
+            assertNotNull(m, "Should find String.length()");
+            assertEquals("length", m.getName());
+        }
+
+        @Test
+        @DisplayName("finds inherited public method")
+        void findsInheritedMethod() {
+            Method m = VS2ShipBridge.findMethod(HashMap.class, "size");
+            assertNotNull(m, "Should find Map.size() via HashMap");
+            assertEquals("size", m.getName());
+        }
+
+        @Test
+        @DisplayName("returns null for non-existent method")
+        void returnsNullForMissing() {
+            Method m = VS2ShipBridge.findMethod(String.class, "nonExistentMethod12345");
+            assertNull(m, "Should return null for non-existent method");
+        }
+
+        @Test
+        @DisplayName("finds method with specific parameter types")
+        void findsMethodWithParams() {
+            Method m = VS2ShipBridge.findMethod(String.class, "substring", int.class);
+            assertNotNull(m, "Should find String.substring(int)");
+            assertEquals("substring", m.getName());
+            assertEquals(1, m.getParameterCount());
+        }
+
+        @Test
+        @DisplayName("returns null when parameter types don't match")
+        void returnsNullWhenParamsMismatch() {
+            Method m = VS2ShipBridge.findMethod(String.class, "substring", double.class);
+            assertNull(m, "Should return null when param types don't match");
+        }
+
+        @Test
+        @DisplayName("finds interface default method")
+        void findsInterfaceMethod() {
+            Method m = VS2ShipBridge.findMethod(Map.class, "size");
+            assertNotNull(m, "Should find size() on Map interface");
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    //  Helper
+    // ═══════════════════════════════════════════════════════════════
+
+    private static StructureFragment makeFragment(Map<BlockPos, BlockState> blocks,
+            double comX, double comY, double comZ) {
+        Map<BlockPos, RMaterial> mats = new HashMap<>();
+        for (BlockPos p : blocks.keySet()) {
+            mats.put(p, DefaultMaterial.CONCRETE);
+        }
+        return new StructureFragment(
+            UUID.randomUUID(),
+            blocks,
+            mats,
+            comX, comY, comZ,
+            1000.0, // totalMass
+            0f, -1.5f, 0f, // vel
+            0f, 0f, 0f,     // angVel
+            0L               // creationTick
+        );
+    }
+}


### PR DESCRIPTION
全面優化 Valkyrie Skies 2 連接器：

效能 (P1-P4):
- 反射快取：所有 Class/Constructor/Method 解析從每次 ~40 次降至 0 次
- isAvailable() 快取：建構子中快取 ModList 結果，不再每次查詢
- 移除 assembleAsShip 內的雙重 isAvailable 檢查
- Constructor 快取減少 JOML Vector 反射開銷

Bug 修復 (B2-B5):
- findMethod: 移除冗餘介面迴圈，新增 getDeclaredMethod 回退支援 package-private 方法
- setAccessible: 新增 try-catch 處理 Java 17 InaccessibleObjectException
- anchor 方塊驗證：assembly 前確認方塊未被移除
- trySetMass: 嘗試透過反射設定 VS2 ship 質量（best effort）

架構 (D1-D3):
- IVS2Bridge 擴展：新增 tickActiveShips/getActiveShipCount default methods
- 斷路器：連續 3 次失敗後 cooldown 600 ticks，參考 SidecarBridge 模式
- Ship 生命週期追蹤：監聽 ship 速度，靜止 40 ticks 後放置瓦礫並拆解
- 首次成功 INFO 日誌，確認橋接正常運作
- 新增 VS2ShipBridgeTest 單元測試（nearestBlockToCoM、findMethod）

