### PR TITLE
feat(fluid-render): 速度場驅動 Gerstner 波 + 三斷點修復 + 壓縮視覺效果 + GPU 法線貼圖

### DIFF
--- a/Block Reality/api/src/main/java/com/blockreality/api/BlockRealityMod.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/BlockRealityMod.java
@@ -2,6 +2,7 @@ package com.blockreality.api;
 
 import com.blockreality.api.command.BrCommand;
 import com.blockreality.api.collapse.CollapseManager;
+import com.blockreality.api.physics.fluid.FluidEntityCoupler;
 import com.blockreality.api.config.BRConfig;
 import com.blockreality.api.diagnostic.BrCrashReporter;
 import com.blockreality.api.diagnostic.BrLogCapture;
@@ -105,6 +106,8 @@ public class BlockRealityMod {
         event.enqueueWork(() -> {
             BRNetwork.register();
             VanillaMaterialMap.getInstance().init();
+            // ★ 流體-實體耦合：浮力 + 拖曳力（0.1m sub-cell 精度）
+            FluidEntityCoupler.registerEventListeners();
             LOGGER.info("[BlockReality] Network channel registered, VanillaMaterialMap loaded ({} entries)",
                 VanillaMaterialMap.getInstance().size());
 

--- a/Block Reality/api/src/main/java/com/blockreality/api/client/render/ChiselMeshBuilder.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/client/render/ChiselMeshBuilder.java
@@ -3,15 +3,19 @@ package com.blockreality.api.client.render;
 import com.blockreality.api.chisel.VoxelGrid;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.inventory.InventoryMenu;
 import org.joml.Matrix4f;
 
 /**
  * 體素網格 → 渲染 mesh 建構器（僅顯示，不做物理計算）。
  *
- * 使用 Greedy Meshing 演算法將相鄰體素面合併，
- * 減少渲染的四邊形數量。
+ * 使用面剔除演算法將與空氣相鄰的體素面渲染出來。
+ * 每個 0.1m 子體素對應 RenderType.cutoutMipped() 不透明面。
  *
  * 此類僅在 client 端使用，由 BlockEntityRenderer 呼叫。
  */
@@ -22,9 +26,13 @@ public final class ChiselMeshBuilder {
     private static final int S = VoxelGrid.SIZE; // 10
     private static final float STEP = 1.0f / S;  // 0.1
 
+    // 預設使用石材紋理 — 固定 UV 錨點避免每幀查詢
+    private static final ResourceLocation STONE_SPRITE_LOC =
+            new ResourceLocation("minecraft", "block/stone");
+
     /**
      * 渲染雕刻方塊的體素網格。
-     * 為非完整方塊生成半透明的子體素面。
+     * 為非完整方塊生成子體素面（0.1m 精度）。
      *
      * @param grid       體素網格
      * @param poseStack  渲染矩陣
@@ -44,7 +52,17 @@ public final class ChiselMeshBuilder {
 
         if (grid.isFull()) return; // 完整方塊不需要特殊渲染
 
-        VertexConsumer consumer = buffer.getBuffer(RenderType.translucent());
+        // 從方塊紋理圖集取得石材 sprite，獲取有效的 UV 座標範圍。
+        // 原本 uv(0,0) 指向圖集左上角（空白/透明區域），導致微體素不可見。
+        TextureAtlasSprite sprite = Minecraft.getInstance()
+                .getModelManager()
+                .getAtlas(InventoryMenu.BLOCK_ATLAS)
+                .getSprite(STONE_SPRITE_LOC);
+        float su0 = sprite.getU0(), su1 = sprite.getU1();
+        float sv0 = sprite.getV0(), sv1 = sprite.getV1();
+
+        // cutoutMipped：不透明面渲染通道，效能優於 translucent 且排序正確
+        VertexConsumer consumer = buffer.getBuffer(RenderType.cutoutMipped());
         Matrix4f mat = poseStack.last().pose();
 
         // 逐面渲染：只渲染與空氣相鄰的面
@@ -63,32 +81,32 @@ public final class ChiselMeshBuilder {
                     // -X face
                     if (x == 0 || !grid.get(x - 1, y, z)) {
                         quad(consumer, mat, x0, y0, z0, x0, y1, z0, x0, y1, z1, x0, y0, z1,
-                             -1, 0, 0, r, g, b, alpha, light);
+                             -1, 0, 0, r, g, b, alpha, light, su0, sv0, su1, sv1);
                     }
                     // +X face
                     if (x == S - 1 || !grid.get(x + 1, y, z)) {
                         quad(consumer, mat, x1, y0, z1, x1, y1, z1, x1, y1, z0, x1, y0, z0,
-                             1, 0, 0, r, g, b, alpha, light);
+                             1, 0, 0, r, g, b, alpha, light, su0, sv0, su1, sv1);
                     }
                     // -Y face (bottom)
                     if (y == 0 || !grid.get(x, y - 1, z)) {
                         quad(consumer, mat, x0, y0, z1, x1, y0, z1, x1, y0, z0, x0, y0, z0,
-                             0, -1, 0, r, g, b, alpha, light);
+                             0, -1, 0, r, g, b, alpha, light, su0, sv0, su1, sv1);
                     }
                     // +Y face (top)
                     if (y == S - 1 || !grid.get(x, y + 1, z)) {
                         quad(consumer, mat, x0, y1, z0, x1, y1, z0, x1, y1, z1, x0, y1, z1,
-                             0, 1, 0, r, g, b, alpha, light);
+                             0, 1, 0, r, g, b, alpha, light, su0, sv0, su1, sv1);
                     }
                     // -Z face
                     if (z == 0 || !grid.get(x, y, z - 1)) {
                         quad(consumer, mat, x1, y0, z0, x1, y1, z0, x0, y1, z0, x0, y0, z0,
-                             0, 0, -1, r, g, b, alpha, light);
+                             0, 0, -1, r, g, b, alpha, light, su0, sv0, su1, sv1);
                     }
                     // +Z face
                     if (z == S - 1 || !grid.get(x, y, z + 1)) {
                         quad(consumer, mat, x0, y0, z1, x0, y1, z1, x1, y1, z1, x1, y0, z1,
-                             0, 0, 1, r, g, b, alpha, light);
+                             0, 0, 1, r, g, b, alpha, light, su0, sv0, su1, sv1);
                     }
                 }
             }
@@ -96,7 +114,8 @@ public final class ChiselMeshBuilder {
     }
 
     /**
-     * 發射一個四邊形（4 頂點）。
+     * 發射一個四邊形（4 頂點），UV 對應 sprite 完整範圍。
+     * su0/sv0 = sprite 左上角；su1/sv1 = sprite 右下角。
      */
     private static void quad(VertexConsumer c, Matrix4f mat,
                              float x0, float y0, float z0,
@@ -105,21 +124,22 @@ public final class ChiselMeshBuilder {
                              float x3, float y3, float z3,
                              float nx, float ny, float nz,
                              int r, int g, int b, int a,
-                             int light) {
-        vertex(c, mat, x0, y0, z0, nx, ny, nz, r, g, b, a, light);
-        vertex(c, mat, x1, y1, z1, nx, ny, nz, r, g, b, a, light);
-        vertex(c, mat, x2, y2, z2, nx, ny, nz, r, g, b, a, light);
-        vertex(c, mat, x3, y3, z3, nx, ny, nz, r, g, b, a, light);
+                             int light,
+                             float su0, float sv0, float su1, float sv1) {
+        vertex(c, mat, x0, y0, z0, nx, ny, nz, r, g, b, a, light, su0, sv0);
+        vertex(c, mat, x1, y1, z1, nx, ny, nz, r, g, b, a, light, su0, sv1);
+        vertex(c, mat, x2, y2, z2, nx, ny, nz, r, g, b, a, light, su1, sv1);
+        vertex(c, mat, x3, y3, z3, nx, ny, nz, r, g, b, a, light, su1, sv0);
     }
 
     private static void vertex(VertexConsumer c, Matrix4f mat,
                                float x, float y, float z,
                                float nx, float ny, float nz,
                                int r, int g, int b, int a,
-                               int light) {
+                               int light, float u, float v) {
         c.vertex(mat, x, y, z)
          .color(r, g, b, a)
-         .uv(0, 0)
+         .uv(u, v)
          .uv2(light)
          .normal(nx, ny, nz)
          .endVertex();

--- a/Block Reality/api/src/main/java/com/blockreality/api/client/render/FluidRenderBridge.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/client/render/FluidRenderBridge.java
@@ -1,5 +1,6 @@
 package com.blockreality.api.client.render;
 
+import com.blockreality.api.client.render.effect.BRWaterRenderer;
 import com.blockreality.api.physics.fluid.FluidRegion;
 import com.blockreality.api.physics.fluid.FluidRegionRegistry;
 import net.minecraft.client.Minecraft;
@@ -80,6 +81,11 @@ public class FluidRenderBridge {
         if (!initialized) return;
 
         FluidRegionRegistry registry = FluidRegionRegistry.getInstance();
+
+        // 物理狀態累計（跨所有活動區域取最大值）
+        float maxVelMag = 0.0f;
+        float maxPressure = 0.0f;
+
         for (FluidRegion region : registry.getActiveRegions()) {
             int id = region.getRegionId();
 
@@ -96,12 +102,45 @@ public class FluidRenderBridge {
                 meshCache.remove(id);
             }
 
-            // 粒子發射（Minecraft 原生粒子系統）
+            // 水花粒子發射（Minecraft 原生粒子系統）
             FluidSplashEmitter.emitAtBoundary(
                 region,
                 region.getOriginX(), region.getOriginY(), region.getOriginZ(),
                 (wx, wy, wz, vx, vy, vz) -> spawnSplashParticle(wx, wy, wz, vx, vy, vz)
             );
+
+            // ── 提取物理狀態供水體渲染器使用 ──
+            float[] vx  = region.getVx();
+            float[] vy  = region.getVy();
+            float[] vz  = region.getVz();
+            float regionMaxVelSq = 0.0f;
+            for (int i = 0; i < vx.length; i++) {
+                float spdSq = vx[i]*vx[i] + vy[i]*vy[i] + vz[i]*vz[i];
+                if (spdSq > regionMaxVelSq) regionMaxVelSq = spdSq;
+            }
+            float regionMaxVel = (float) Math.sqrt(regionMaxVelSq);
+            if (regionMaxVel > maxVelMag) maxVelMag = regionMaxVel;
+
+            float[] pressure = region.getPressure();
+            for (float p : pressure) {
+                if (p > maxPressure) maxPressure = p;
+            }
+        }
+
+        // 推送物理狀態到 GL 水體渲染器
+        BRWaterRenderer.setPhysicsVelocityMagnitude(maxVelMag);
+        BRWaterRenderer.setPhysicsCompressionRatio(maxPressure / 101325.0f);
+
+        // 壓縮波 BUBBLE 粒子（壓力超過 4 atm 時觸發）
+        if (maxPressure > 4.0f * 101325.0f) {
+            for (FluidRegion region : registry.getActiveRegions()) {
+                FluidSplashEmitter.emitCompressionWave(
+                    region,
+                    region.getOriginX(), region.getOriginY(), region.getOriginZ(),
+                    maxPressure,
+                    (wx, wy, wz, vx, vy, vz) -> spawnBubbleParticle(wx, wy, wz, vx, vy, vz)
+                );
+            }
         }
     }
 
@@ -187,6 +226,17 @@ public class FluidRenderBridge {
             net.minecraft.core.particles.ParticleTypes.SPLASH,
             wx, wy, wz,
             vx * 0.1, vy * 0.1, vz * 0.1  // 縮放速度以適配粒子系統
+        );
+    }
+
+    private void spawnBubbleParticle(float wx, float wy, float wz,
+                                      float vx, float vy, float vz) {
+        Minecraft mc = Minecraft.getInstance();
+        if (mc.level == null) return;
+        mc.level.addParticle(
+            net.minecraft.core.particles.ParticleTypes.BUBBLE,
+            wx, wy, wz,
+            vx * 0.1, vy * 0.1, vz * 0.1
         );
     }
 }

--- a/Block Reality/api/src/main/java/com/blockreality/api/client/render/FluidSplashEmitter.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/client/render/FluidSplashEmitter.java
@@ -2,8 +2,11 @@ package com.blockreality.api.client.render;
 
 import com.blockreality.api.physics.fluid.FluidRegion;
 import com.blockreality.api.physics.fluid.FluidType;
+import net.minecraft.client.Minecraft;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * 流體粒子發射器 — 在高速流體-固體邊界處發射水花和泡沫粒子。
@@ -35,6 +38,15 @@ public class FluidSplashEmitter {
 
     /** 每 tick 最多發射的粒子數（防止過量） */
     private static final int MAX_PARTICLES_PER_TICK = 64;
+
+    /** 壓縮波觸發壓力閾值（4 atm in Pa） */
+    private static final float COMPRESSION_PRESSURE_THRESHOLD = 4.0f * 101325.0f;
+
+    /** 壓縮波冷卻（regionId → 上次觸發的遊戲 tick） */
+    private static final ConcurrentHashMap<Integer, Long> compressionCooldown = new ConcurrentHashMap<>();
+
+    /** 壓縮波冷卻期（ticks） */
+    private static final int COMPRESSION_COOLDOWN_TICKS = 10;
 
     /**
      * 掃描 FluidRegion 的 sub-cell 速度場，在高速邊界處發射粒子。
@@ -86,6 +98,76 @@ public class FluidSplashEmitter {
                     emitted++;
                 }
             }
+        }
+    }
+
+    /**
+     * 壓縮波 BUBBLE 粒子發射 — 壓力超過 4 atm 時，從高壓 sub-cell 向四周散射 BUBBLE 粒子。
+     *
+     * <p>每個 region 最多每 {@link #COMPRESSION_COOLDOWN_TICKS} ticks 觸發一次。
+     *
+     * @param region       流體區域
+     * @param worldOx      區域世界原點 X（方塊座標）
+     * @param worldOy      區域世界原點 Y
+     * @param worldOz      區域世界原點 Z
+     * @param maxPressure  全場最大壓力（Pa），用於確定擴散速度
+     * @param emitSink     粒子發射回調
+     */
+    public static void emitCompressionWave(FluidRegion region,
+                                            int worldOx, int worldOy, int worldOz,
+                                            float maxPressure,
+                                            ParticleEmitSink emitSink) {
+        if (maxPressure < COMPRESSION_PRESSURE_THRESHOLD) return;
+
+        Minecraft mc = Minecraft.getInstance();
+        if (mc.level == null) return;
+        long currentTick = mc.level.getGameTime();
+
+        int id = region.getRegionId();
+        Long lastTick = compressionCooldown.get(id);
+        if (lastTick != null && currentTick - lastTick < COMPRESSION_COOLDOWN_TICKS) return;
+        compressionCooldown.put(id, currentTick);
+
+        // 找到最高壓 sub-cell（用 block-level pressure 陣列）
+        float[] pressure = region.getPressure();
+        int subSX = region.getSubSX();
+        int subSY = region.getSubSY();
+        int subSZ = region.getSubSZ();
+
+        // block-level 陣列的索引範圍可能小於 sub-cell 陣列
+        int bSX = region.getSizeX();
+        int bSY = region.getSizeY();
+        int bSZ = region.getSizeZ();
+
+        int peakBx = bSX / 2, peakBy = bSY / 2, peakBz = bSZ / 2;
+        float peakP = 0.0f;
+        for (int bz = 0; bz < bSZ; bz++) {
+            for (int by = 0; by < bSY; by++) {
+                for (int bx = 0; bx < bSX; bx++) {
+                    int idx = bx + by * bSX + bz * bSX * bSY;
+                    if (pressure[idx] > peakP) {
+                        peakP = pressure[idx];
+                        peakBx = bx; peakBy = by; peakBz = bz;
+                    }
+                }
+            }
+        }
+
+        // 世界座標（方塊中心）
+        float cx = worldOx + peakBx + 0.5f;
+        float cy = worldOy + peakBy + 0.5f;
+        float cz = worldOz + peakBz + 0.5f;
+
+        // 發射 8~12 顆 BUBBLE 粒子向四周擴散
+        float pressureRatio = maxPressure / 101325.0f;
+        float baseSpeed = 0.3f + pressureRatio * 0.1f;
+        int count = 8 + (int)(Math.random() * 5);  // 8~12
+        for (int i = 0; i < count; i++) {
+            double angle = (2.0 * Math.PI * i) / count;
+            float dvx = (float)(Math.cos(angle) * baseSpeed);
+            float dvz = (float)(Math.sin(angle) * baseSpeed);
+            float dvy = baseSpeed * 0.5f;
+            emitSink.emit(cx, cy, cz, dvx, dvy, dvz);
         }
     }
 

--- a/Block Reality/api/src/main/java/com/blockreality/api/client/render/FluidSurfaceMesher.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/client/render/FluidSurfaceMesher.java
@@ -89,9 +89,106 @@ public class FluidSurfaceMesher {
     }
 
     /**
+     * 像素風水體渲染 — 每個 {@code vof > 0.5} 的 sub-cell 渲染為一個 0.1m 面剔除立方體。
+     *
+     * <p>輸出格式與 {@link #meshRegion} 相同（交錯 {@code [x,y,z,nx,ny,nz]} FloatBuffer），
+     * 可直接替換 Marching Cubes 路徑。
+     *
+     * <p>效果：每個流體格是獨立的 0.1m 小方塊，邊緣清晰、像素感強。
+     * 水動時這些小方塊隨 VOF 場移動，形成「水球」視覺。
+     *
+     * @param region  流體區域
+     * @param worldOx 區域世界原點 X
+     * @param worldOy 區域世界原點 Y
+     * @param worldOz 區域世界原點 Z
+     * @return 包含像素立方體網格的 FloatBuffer，無流體時回傳 null
+     */
+    public static FloatBuffer meshRegionVoxelStyle(FluidRegion region,
+                                                   int worldOx, int worldOy, int worldOz) {
+        int subSX = region.getSubSX();
+        int subSY = region.getSubSY();
+        int subSZ = region.getSubSZ();
+        float[] vof = region.getVof();
+
+        // ── 雙 pass：先計算曝露面數，再精確分配 ──
+        int exposedFaces = 0;
+        for (int gz = 0; gz < subSZ; gz++)
+        for (int gy = 0; gy < subSY; gy++)
+        for (int gx = 0; gx < subSX; gx++) {
+            if (!isFluid(vof, gx, gy, gz, subSX, subSY, subSZ)) continue;
+            if (!isFluid(vof, gx+1, gy,   gz,   subSX, subSY, subSZ)) exposedFaces++;
+            if (!isFluid(vof, gx-1, gy,   gz,   subSX, subSY, subSZ)) exposedFaces++;
+            if (!isFluid(vof, gx,   gy+1, gz,   subSX, subSY, subSZ)) exposedFaces++;
+            if (!isFluid(vof, gx,   gy-1, gz,   subSX, subSY, subSZ)) exposedFaces++;
+            if (!isFluid(vof, gx,   gy,   gz+1, subSX, subSY, subSZ)) exposedFaces++;
+            if (!isFluid(vof, gx,   gy,   gz-1, subSX, subSY, subSZ)) exposedFaces++;
+        }
+        if (exposedFaces == 0) return null;
+
+        // 每個曝露面 = 2 三角形 × 3 頂點 × 6 floats (pos + normal) = 36 floats
+        float[] tempBuf = new float[exposedFaces * 36];
+        int idx = 0;
+
+        for (int gz = 0; gz < subSZ; gz++)
+        for (int gy = 0; gy < subSY; gy++)
+        for (int gx = 0; gx < subSX; gx++) {
+            if (!isFluid(vof, gx, gy, gz, subSX, subSY, subSZ)) continue;
+
+            float wx = worldOx + gx * CELL_SIZE;
+            float wy = worldOy + gy * CELL_SIZE;
+            float wz = worldOz + gz * CELL_SIZE;
+            float s  = CELL_SIZE;
+
+            // +X 面（法線 1,0,0）
+            if (!isFluid(vof, gx+1, gy, gz, subSX, subSY, subSZ))
+                idx = emitQuad(tempBuf, idx,
+                    wx+s, wy,   wz,    wx+s, wy,   wz+s,
+                    wx+s, wy+s, wz+s,  wx+s, wy+s, wz,
+                    1, 0, 0);
+            // -X 面（法線 -1,0,0）
+            if (!isFluid(vof, gx-1, gy, gz, subSX, subSY, subSZ))
+                idx = emitQuad(tempBuf, idx,
+                    wx, wy,   wz+s,  wx, wy,   wz,
+                    wx, wy+s, wz,    wx, wy+s, wz+s,
+                    -1, 0, 0);
+            // +Y 面（法線 0,1,0 — 水面頂部，最常見曝露面）
+            if (!isFluid(vof, gx, gy+1, gz, subSX, subSY, subSZ))
+                idx = emitQuad(tempBuf, idx,
+                    wx,   wy+s, wz,    wx+s, wy+s, wz,
+                    wx+s, wy+s, wz+s,  wx,   wy+s, wz+s,
+                    0, 1, 0);
+            // -Y 面（法線 0,-1,0）
+            if (!isFluid(vof, gx, gy-1, gz, subSX, subSY, subSZ))
+                idx = emitQuad(tempBuf, idx,
+                    wx,   wy, wz+s,  wx+s, wy, wz+s,
+                    wx+s, wy, wz,    wx,   wy, wz,
+                    0, -1, 0);
+            // +Z 面（法線 0,0,1）
+            if (!isFluid(vof, gx, gy, gz+1, subSX, subSY, subSZ))
+                idx = emitQuad(tempBuf, idx,
+                    wx+s, wy,   wz+s,  wx,   wy,   wz+s,
+                    wx,   wy+s, wz+s,  wx+s, wy+s, wz+s,
+                    0, 0, 1);
+            // -Z 面（法線 0,0,-1）
+            if (!isFluid(vof, gx, gy, gz-1, subSX, subSY, subSZ))
+                idx = emitQuad(tempBuf, idx,
+                    wx,   wy,   wz,    wx+s, wy,   wz,
+                    wx+s, wy+s, wz,    wx,   wy+s, wz,
+                    0, 0, -1);
+        }
+
+        if (idx == 0) return null;
+        FloatBuffer buf = MemoryUtil.memAllocFloat(idx);
+        buf.put(tempBuf, 0, idx);
+        buf.flip();
+        return buf;
+    }
+
+    /**
      * 增量更新 — 僅重建包含 dirty sub-cell 的 chunk（2³ blocks 為一個 dirty chunk）。
      *
      * <p>此方法供每 tick 呼叫，避免完整重建整個網格。
+     * 使用像素風渲染（{@link #meshRegionVoxelStyle}）取代 Marching Cubes。
      *
      * @param region  流體區域
      * @param worldOx 區域世界原點 X
@@ -106,8 +203,44 @@ public class FluidSurfaceMesher {
         if (existing != null) {
             MemoryUtil.memFree(existing);
         }
-        // 完整重建（增量版本在後續迭代中實作）
-        return meshRegion(region, worldOx, worldOy, worldOz);
+        // 像素風渲染（每個 vof>0.5 的 sub-cell 為一個 0.1m 面剔除立方體）
+        return meshRegionVoxelStyle(region, worldOx, worldOy, worldOz);
+    }
+
+    // ─── 像素風渲染輔助 ───
+
+    /** 判斷指定 sub-cell 是否為流體（VOF > ISOVALUE）。邊界外視為空氣。 */
+    private static boolean isFluid(float[] vof, int gx, int gy, int gz,
+                                   int subSX, int subSY, int subSZ) {
+        if (gx < 0 || gx >= subSX || gy < 0 || gy >= subSY || gz < 0 || gz >= subSZ)
+            return false;
+        return vof[gx + gy * subSX + gz * subSX * subSY] > ISOVALUE;
+    }
+
+    /**
+     * 將一個四邊形（4 角點）拆為兩個三角形寫入 {@code out}，共 36 個 float。
+     *
+     * @param out     輸出陣列
+     * @param idx     當前寫入位置
+     * @param x0..z3  4 個角點座標（CCW 順序，從正法線方向看）
+     * @param nx,ny,nz 面法線
+     * @return 更新後的寫入位置（idx + 36）
+     */
+    private static int emitQuad(float[] out, int idx,
+                                 float x0, float y0, float z0,
+                                 float x1, float y1, float z1,
+                                 float x2, float y2, float z2,
+                                 float x3, float y3, float z3,
+                                 float nx, float ny, float nz) {
+        // 三角形 1：v0, v1, v2
+        out[idx++]=x0; out[idx++]=y0; out[idx++]=z0; out[idx++]=nx; out[idx++]=ny; out[idx++]=nz;
+        out[idx++]=x1; out[idx++]=y1; out[idx++]=z1; out[idx++]=nx; out[idx++]=ny; out[idx++]=nz;
+        out[idx++]=x2; out[idx++]=y2; out[idx++]=z2; out[idx++]=nx; out[idx++]=ny; out[idx++]=nz;
+        // 三角形 2：v0, v2, v3
+        out[idx++]=x0; out[idx++]=y0; out[idx++]=z0; out[idx++]=nx; out[idx++]=ny; out[idx++]=nz;
+        out[idx++]=x2; out[idx++]=y2; out[idx++]=z2; out[idx++]=nx; out[idx++]=ny; out[idx++]=nz;
+        out[idx++]=x3; out[idx++]=y3; out[idx++]=z3; out[idx++]=nx; out[idx++]=ny; out[idx++]=nz;
+        return idx;
     }
 
     // ─── Marching Cubes 核心 ───

--- a/Block Reality/api/src/main/java/com/blockreality/api/client/render/effect/BRWaterRenderer.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/client/render/effect/BRWaterRenderer.java
@@ -65,17 +65,37 @@ public class BRWaterRenderer {
     /** 吸收係數（Beer-Lambert） */
     private static final Vector3f ABSORPTION_COEFF = new Vector3f(0.45f, 0.06f, 0.03f);
 
-    /** 泡沫閾值（深度差小於此值顯示泡沫） */
-    private static final float FOAM_DEPTH_THRESHOLD = 0.8f;
+    /** 泡沫閾值（深度差小於此值顯示泡沫；可由節點圖動態調整） */
+    private static volatile float foamDepthThreshold = 0.8f;
 
     /** 泡沫強度 */
-    private static final float FOAM_INTENSITY = 0.7f;
+    private static volatile float foamIntensity = 0.7f;
 
     /** 焦散強度 */
-    private static final float CAUSTICS_INTENSITY = 0.3f;
+    private static volatile float causticsIntensity = 0.3f;
 
     /** 焦散紋理縮放 */
-    private static final float CAUSTICS_SCALE = 0.05f;
+    private static volatile float causticsScale = 0.05f;
+
+    // ========================= PFSF-Fluid 物理驅動狀態 =========================
+
+    /** 物理速度量值（由 FluidRenderBridge 每 tick 更新，驅動 Gerstner 波振幅） */
+    private static volatile float physicsVelocityMagnitude = 0.0f;
+
+    /** 物理壓縮比（localPressure / 101325 Pa；> 1 表示高壓，驅動水色偏白） */
+    private static volatile float physicsCompressionRatio = 1.0f;
+
+    /** 焦散動畫速度倍率（由 WaterCausticsNode 每幀更新） */
+    private static volatile float causticsAnimSpeedMult = 1.0f;
+
+    /** 高壓壓縮時的水色目標（淡藍白） */
+    private static final Vector3f COMPRESSION_WHITE = new Vector3f(0.9f, 0.95f, 1.0f);
+
+    /** 物理法線貼圖紋理 ID（由 GPU 端 fluid_surface_normal.comp 寫入；0 表示未初始化） */
+    private static int physicsNormalMapTex = 0;
+
+    /** 物理法線混合權重（0 = 純 Gerstner，1 = 純物理法線；預設 40% 物理） */
+    private static final float PHYSICS_NORMAL_BLEND = 0.4f;
 
     // ========================= GL 資源 =========================
 
@@ -230,19 +250,23 @@ public class BRWaterRenderer {
         }
         shader.setUniformInt("u_waveCount", WAVE_PARAMS.length);
 
-        // 水體顏色
+        // 水體顏色（高壓時線性插值至壓縮白色，最大混合 100%）
+        float compressionTint = Math.min(1.0f, (physicsCompressionRatio - 1.0f) * 0.3f);
         shader.setUniformVec3("u_deepWaterColor",
-            DEEP_WATER_COLOR.x, DEEP_WATER_COLOR.y, DEEP_WATER_COLOR.z);
+            lerp(DEEP_WATER_COLOR.x, COMPRESSION_WHITE.x, compressionTint),
+            lerp(DEEP_WATER_COLOR.y, COMPRESSION_WHITE.y, compressionTint),
+            lerp(DEEP_WATER_COLOR.z, COMPRESSION_WHITE.z, compressionTint));
         shader.setUniformVec3("u_shallowWaterColor",
             SHALLOW_WATER_COLOR.x, SHALLOW_WATER_COLOR.y, SHALLOW_WATER_COLOR.z);
         shader.setUniformVec3("u_absorptionCoeff",
             ABSORPTION_COEFF.x, ABSORPTION_COEFF.y, ABSORPTION_COEFF.z);
 
-        // 泡沫 + 焦散
-        shader.setUniformFloat("u_foamThreshold", FOAM_DEPTH_THRESHOLD);
-        shader.setUniformFloat("u_foamIntensity", FOAM_INTENSITY);
-        shader.setUniformFloat("u_causticsIntensity", CAUSTICS_INTENSITY);
-        shader.setUniformFloat("u_causticsScale", CAUSTICS_SCALE);
+        // 泡沫 + 焦散（使用物理驅動的可變值）
+        shader.setUniformFloat("u_foamThreshold", foamDepthThreshold);
+        shader.setUniformFloat("u_foamIntensity", foamIntensity);
+        shader.setUniformFloat("u_causticsIntensity", causticsIntensity);
+        shader.setUniformFloat("u_causticsScale", causticsScale);
+        shader.setUniformFloat("u_causticsAnimSpeedMult", causticsAnimSpeedMult);
 
         // 太陽資訊（預設值 — 大氣引擎已於 2.0 廢棄）
         Vector3f sunDir = new Vector3f(0.0f, 1.0f, 0.0f); // 預設正午太陽方向
@@ -254,6 +278,13 @@ public class BRWaterRenderer {
         GL13.glActiveTexture(GL13.GL_TEXTURE4);
         GL11.glBindTexture(GL11.GL_TEXTURE_2D, reflectionColorTex);
         shader.setUniformInt("u_reflectionTex", 4);
+
+        // 綁定物理法線貼圖（fluid_surface_normal.comp 輸出）
+        GL13.glActiveTexture(GL13.GL_TEXTURE5);
+        GL11.glBindTexture(GL11.GL_TEXTURE_2D, physicsNormalMapTex);
+        shader.setUniformInt("u_physicsNormalMap", 5);
+        shader.setUniformFloat("u_physicsNormalBlend",
+            physicsNormalMapTex != 0 ? PHYSICS_NORMAL_BLEND : 0.0f);
     }
 
     // ========================= Gerstner 波浪 CPU 計算 =========================
@@ -267,8 +298,10 @@ public class BRWaterRenderer {
      */
     public static float computeWaveHeight(float x, float z) {
         float height = 0.0f;
+        // 物理速度場驅動振幅放大（高速區最多增加 30%）
+        float physicsAmpScale = 1.0f + physicsVelocityMagnitude * 0.3f;
         for (float[] wave : WAVE_PARAMS) {
-            float amp = wave[0];
+            float amp = wave[0] * physicsAmpScale;
             float wavelength = wave[1];
             float speed = wave[2];
             float dirAngle = wave[3];
@@ -287,8 +320,9 @@ public class BRWaterRenderer {
      */
     public static Vector3f computeWaveNormal(float x, float z) {
         float nx = 0.0f, nz = 0.0f;
+        float physicsAmpScale = 1.0f + physicsVelocityMagnitude * 0.3f;
         for (float[] wave : WAVE_PARAMS) {
-            float amp = wave[0];
+            float amp = wave[0] * physicsAmpScale;
             float wavelength = wave[1];
             float speed = wave[2];
             float dirAngle = wave[3];
@@ -316,5 +350,47 @@ public class BRWaterRenderer {
     public static int getReflectionFBO() { return reflectionFBO; }
 
     public static boolean isInitialized() { return initialized; }
+
+    // ========================= 物理驅動設定（由 FluidRenderBridge / 節點圖呼叫）=========================
+
+    /**
+     * 由 {@code FluidRenderBridge} 每 tick 推送流體最大速度量值（m/s）。
+     * 驅動 Gerstner 波振幅放大（高速區最多 +30%）。
+     */
+    public static void setPhysicsVelocityMagnitude(float velMag) {
+        physicsVelocityMagnitude = Math.max(0.0f, velMag);
+    }
+
+    /**
+     * 由 {@code FluidRenderBridge} 每 tick 推送壓縮比（localPressure / 101325 Pa）。
+     * > 1 表示高壓；驅動水色線性插值至淡藍白。
+     */
+    public static void setPhysicsCompressionRatio(float ratio) {
+        physicsCompressionRatio = Math.max(1.0f, ratio);
+    }
+
+    /**
+     * 由 {@code WaterCausticsNode} 推送焦散動畫速度倍率。
+     * 傳入 {@code shader.u_causticsAnimSpeedMult}。
+     */
+    public static void setCausticsAnimSpeed(float speedMult) {
+        causticsAnimSpeedMult = Math.max(0.1f, speedMult);
+    }
+
+    /**
+     * 由 Vulkan 端 {@code fluid_surface_normal.comp} 輸出管線設定物理法線貼圖 ID。
+     * 0 表示不可用（回退到純 Gerstner 法線）。
+     */
+    public static void setPhysicsNormalMapTex(int texId) {
+        physicsNormalMapTex = texId;
+    }
+
+    public static int getPhysicsNormalMapTex() { return physicsNormalMapTex; }
+
+    // ─── 工具 ───
+
+    private static float lerp(float a, float b, float t) {
+        return a + (b - a) * t;
+    }
 }
 

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/fluid/FluidCPUSolver.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/fluid/FluidCPUSolver.java
@@ -25,6 +25,14 @@ public class FluidCPUSolver {
 
     private static final Logger LOGGER = LogManager.getLogger("BR-FluidCPU");
 
+    /**
+     * Sub-cell 邊長（公尺）= BLOCK_SIZE_M / SUB = 0.1 m。
+     * Semi-Lagrangian 回追需以此值為分母，將 m/s 速度轉換為
+     * 每 tick 的 sub-cell 位移。使用 BLOCK_SIZE_M（1.0m）會造成
+     * 位移值偏小 10 倍，流體幾乎靜止。
+     */
+    private static final float CELL_SIZE_M = FluidConstants.BLOCK_SIZE_M / FluidRegion.SUB; // 0.1 m
+
     // 6 鄰居偏移：+X, -X, +Y, -Y, +Z, -Z
     private static final int[][] NEIGHBOR_OFFSETS = {
         {1, 0, 0}, {-1, 0, 0},
@@ -303,9 +311,10 @@ public class FluidCPUSolver {
                 for (int gx = 0; gx < sx; gx++) {
                     int idx = gx + gy * sx + gz * sx * sy;
                     // 回追粒子位置（semi-Lagrangian backward advection）
-                    float px = gx - dt * vx[idx] / FluidConstants.BLOCK_SIZE_M;
-                    float py = gy - dt * vy[idx] / FluidConstants.BLOCK_SIZE_M;
-                    float pz = gz - dt * vz[idx] / FluidConstants.BLOCK_SIZE_M;
+                    // 速度 m/s ÷ sub-cell 邊長 0.1m = sub-cell/s，再乘 dt 得 sub-cell 位移
+                    float px = gx - dt * vx[idx] / CELL_SIZE_M;
+                    float py = gy - dt * vy[idx] / CELL_SIZE_M;
+                    float pz = gz - dt * vz[idx] / CELL_SIZE_M;
                     px = Math.max(0f, Math.min(sx - 1.001f, px));
                     py = Math.max(0f, Math.min(sy - 1.001f, py));
                     pz = Math.max(0f, Math.min(sz - 1.001f, pz));
@@ -317,7 +326,7 @@ public class FluidCPUSolver {
         }
     }
 
-
+    /**
      * 對 vx/vy/vz 陣列進行對流，保持速度場的 Lagrangian 守恆性。
      *
      * @param r  流體區域
@@ -332,10 +341,11 @@ public class FluidCPUSolver {
             for (int gy = 0; gy < sy; gy++) {
                 for (int gx = 0; gx < sx; gx++) {
                     int idx = gx + gy * sx + gz * sx * sy;
-                    // 回追粒子位置（半步長 backward advection）
-                    float px = gx - dt * vxOld[idx] / FluidConstants.BLOCK_SIZE_M;
-                    float py = gy - dt * vyOld[idx] / FluidConstants.BLOCK_SIZE_M;
-                    float pz = gz - dt * vzOld[idx] / FluidConstants.BLOCK_SIZE_M;
+                    // 回追粒子位置（semi-Lagrangian backward advection）
+                    // 速度 m/s ÷ CELL_SIZE_M 0.1m → sub-cell 位移
+                    float px = gx - dt * vxOld[idx] / CELL_SIZE_M;
+                    float py = gy - dt * vyOld[idx] / CELL_SIZE_M;
+                    float pz = gz - dt * vzOld[idx] / CELL_SIZE_M;
                     // clamp 到域內
                     px = Math.max(0f, Math.min(sx - 1.001f, px));
                     py = Math.max(0f, Math.min(sy - 1.001f, py));

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/fluid/FluidCPUSolver.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/fluid/FluidCPUSolver.java
@@ -281,7 +281,43 @@ public class FluidCPUSolver {
     // ═══════════════════════════════════════════════════════
 
     /**
-     * Step 1：Semi-Lagrangian advection（回追粒子，bilinear 插值）。
+     * Step 0：Semi-Lagrangian 標量場對流（VOF、密度等純量通用）。
+     *
+     * <p>與 {@link #advectVelocity} 使用相同的回追算法；
+     * 但作用於單一 {@code float[]} 場，並將結果 clamp 到 [0, 1]（適用於 VOF）。
+     *
+     * <p>★ 這是 VOF 靜止 bug 的修復：不呼叫此方法時，vof[] 永遠不變，
+     * Marching Cubes / 像素風渲染永遠顯示初始液面，無波動或流動。
+     *
+     * @param field 要對流的標量場（原地更新，結果 clamp 至 [0, 1]）
+     * @param r     流體區域（提供速度場 vx/vy/vz）
+     * @param dt    時間步長（s）
+     */
+    public static void advectScalar(float[] field, FluidRegion r, float dt) {
+        int sx = r.getSubSX(), sy = r.getSubSY(), sz = r.getSubSZ();
+        float[] vx = r.getVx(), vy = r.getVy(), vz = r.getVz();
+        float[] old = field.clone();  // 雙緩衝：讀 old，寫 field
+
+        for (int gz = 0; gz < sz; gz++) {
+            for (int gy = 0; gy < sy; gy++) {
+                for (int gx = 0; gx < sx; gx++) {
+                    int idx = gx + gy * sx + gz * sx * sy;
+                    // 回追粒子位置（semi-Lagrangian backward advection）
+                    float px = gx - dt * vx[idx] / FluidConstants.BLOCK_SIZE_M;
+                    float py = gy - dt * vy[idx] / FluidConstants.BLOCK_SIZE_M;
+                    float pz = gz - dt * vz[idx] / FluidConstants.BLOCK_SIZE_M;
+                    px = Math.max(0f, Math.min(sx - 1.001f, px));
+                    py = Math.max(0f, Math.min(sy - 1.001f, py));
+                    pz = Math.max(0f, Math.min(sz - 1.001f, pz));
+                    float newVal = trilinear(old, px, py, pz, sx, sy, sz);
+                    // VOF 必須保持在 [0, 1]
+                    field[idx] = Math.max(0f, Math.min(1f, newVal));
+                }
+            }
+        }
+    }
+
+
      * 對 vx/vy/vz 陣列進行對流，保持速度場的 Lagrangian 守恆性。
      *
      * @param r  流體區域
@@ -454,6 +490,7 @@ public class FluidCPUSolver {
      */
     public static void stableFluidsStep(FluidRegion r, float dt, int pressureIters) {
         advectVelocity(r, dt);
+        advectScalar(r.getVof(), r, dt);   // ★ 修復：VOF 對流使液面隨速度場移動
         applyGravity(r, dt);
         jacobiPressureSolve(r, pressureIters);
         projectVelocity(r);

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/fluid/FluidEntityCoupler.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/fluid/FluidEntityCoupler.java
@@ -1,0 +1,218 @@
+package com.blockreality.api.physics.fluid;
+
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.entity.living.LivingEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+
+/**
+ * 流體-實體耦合器 — 每 tick 對處於流體中的活體實體施加浮力與拖曳力。
+ *
+ * <h3>物理模型</h3>
+ * <ul>
+ *   <li><b>浮力</b>（阿基米德）：F_b = ρ × g × V_submerged</li>
+ *   <li><b>拖曳力</b>（流速驅動）：F_d = ½ × ρ × Cd × A × v_rel²，方向平行流速</li>
+ * </ul>
+ *
+ * <h3>精度</h3>
+ * <p>AABB → sub-cell 格映射使用 0.1m（{@link FluidRegion#SUB}）精度。
+ * 部分重疊的 AABB 邊緣格計為全覆蓋（保守估計）。
+ *
+ * <h3>查詢工具</h3>
+ * <p>{@link #querySurfaceY} 允許在任意 XZ 世界座標查詢液面高度，
+ * 可用於客戶端波浪碰撞偵測或 AI 導航。
+ *
+ * <h3>啟用方式</h3>
+ * <p>在 Mod 初始化時呼叫 {@link #registerEventListeners()}。
+ * 已在 {@link com.blockreality.api.BlockRealityMod} 的 commonSetup 中自動呼叫。
+ *
+ * @see FluidRegion
+ * @see FluidRegionRegistry
+ */
+public class FluidEntityCoupler {
+
+    // ── 流體物理常數 ──
+    private static final float WATER_DENSITY     = 1000f;  // kg/m³
+    private static final float DRAG_CD           = 0.8f;   // 人形阻力係數
+    private static final float ENTITY_CROSS_AREA = 0.5f;   // m²（人形正面截面估算）
+    private static final float GRAVITY           = 9.81f;  // m/s²
+
+    // ── Minecraft 模擬常數 ──
+    private static final float TICK_DT      = 0.05f;  // 1/20 s
+    private static final float ENTITY_MASS  = 70f;    // kg（人形）
+    private static final float MAX_DV       = 0.5f;   // m/s per tick，防爆速上限
+    private static final float FLUID_VOF_THRESHOLD = 0.5f;
+
+    // ── 建構子私有（全靜態工具類）──
+    private FluidEntityCoupler() {}
+
+    /**
+     * 向 Forge EventBus 註冊此類的事件監聽器。
+     * 需在 {@code FMLCommonSetupEvent.enqueueWork()} 中呼叫一次。
+     */
+    public static void registerEventListeners() {
+        MinecraftForge.EVENT_BUS.register(FluidEntityCoupler.class);
+    }
+
+    // ════════════════════════════════════════════════════
+    //  Forge Event — 每 tick 施加流體力
+    // ════════════════════════════════════════════════════
+
+    /**
+     * 每 living entity tick 觸發（SERVER side）。
+     * 掃描所有活動 FluidRegion，計算並施加浮力 + 拖曳力。
+     */
+    @SubscribeEvent
+    public static void onLivingTick(LivingEvent.LivingTickEvent event) {
+        LivingEntity entity = event.getEntity();
+        if (entity.level().isClientSide()) return;
+
+        AABB box = entity.getBoundingBox();
+        FluidRegionRegistry registry = FluidRegionRegistry.getInstance();
+
+        double totalFx = 0, totalFy = 0, totalFz = 0;
+        boolean inFluid = false;
+
+        for (FluidRegion region : registry.getActiveRegions()) {
+            if (!overlapsRegion(box, region)) continue;
+
+            ForceResult f = computeForce(box, region);
+            if (f.fluidCells == 0) continue;
+
+            inFluid = true;
+            totalFx += f.fx;
+            totalFy += f.fy;
+            totalFz += f.fz;
+        }
+
+        if (!inFluid) return;
+
+        // 合力 → 速度增量（F = ma → dv = F·dt/m）
+        double dvx = clampDv(totalFx * TICK_DT / ENTITY_MASS);
+        double dvy = clampDv(totalFy * TICK_DT / ENTITY_MASS);
+        double dvz = clampDv(totalFz * TICK_DT / ENTITY_MASS);
+
+        Vec3 cur = entity.getDeltaMovement();
+        entity.setDeltaMovement(cur.x + dvx, cur.y + dvy, cur.z + dvz);
+    }
+
+    // ════════════════════════════════════════════════════
+    //  公開工具：液面高度查詢
+    // ════════════════════════════════════════════════════
+
+    /**
+     * 查詢指定 XZ 世界座標的流體表面高度（Y 座標）。
+     *
+     * <p>從 sub-cell 網格頂部向下掃描，找到第一個 {@code vof > 0.5} 的格，
+     * 並以線性插值計算精確 Y 高度（精度 < 0.1m）。
+     *
+     * @param region 流體區域
+     * @param wx     世界座標 X
+     * @param wz     世界座標 Z
+     * @return 液面 Y 世界座標（float）；無流體時回傳 {@code region.getOriginY()}
+     */
+    public static float querySurfaceY(FluidRegion region, float wx, float wz) {
+        final float cellSize = 0.1f;
+        int subSX = region.getSubSX();
+        int subSY = region.getSubSY();
+        int subSZ = region.getSubSZ();
+        float[] vof = region.getVof();
+
+        int gx = clamp((int)((wx - region.getOriginX()) / cellSize), 0, subSX - 1);
+        int gz = clamp((int)((wz - region.getOriginZ()) / cellSize), 0, subSZ - 1);
+
+        for (int gy = subSY - 1; gy >= 0; gy--) {
+            int idx = gx + gy * subSX + gz * subSX * subSY;
+            if (vof[idx] > FLUID_VOF_THRESHOLD) {
+                // 線性插值：求等值面精確 Y
+                float vAbove = (gy + 1 < subSY)
+                    ? vof[gx + (gy + 1) * subSX + gz * subSX * subSY]
+                    : 0f;
+                float vHere = vof[idx];
+                float frac = (vHere - FLUID_VOF_THRESHOLD) / (vHere - vAbove + 1e-6f);
+                frac = Math.max(0f, Math.min(1f, frac));
+                return region.getOriginY() + (gy + 1 - frac) * cellSize;
+            }
+        }
+        return region.getOriginY();
+    }
+
+    // ════════════════════════════════════════════════════
+    //  內部實作
+    // ════════════════════════════════════════════════════
+
+    private static ForceResult computeForce(AABB box, FluidRegion region) {
+        final float cellSize = 0.1f;
+        int subSX = region.getSubSX();
+        int subSY = region.getSubSY();
+        int subSZ = region.getSubSZ();
+        float[] vx = region.getVx(), vy = region.getVy(), vz = region.getVz();
+        float[] vof = region.getVof();
+
+        // AABB → sub-cell 格座標範圍（clamp 到域內）
+        int x0 = clamp((int)((box.minX - region.getOriginX()) / cellSize), 0, subSX - 1);
+        int y0 = clamp((int)((box.minY - region.getOriginY()) / cellSize), 0, subSY - 1);
+        int z0 = clamp((int)((box.minZ - region.getOriginZ()) / cellSize), 0, subSZ - 1);
+        int x1 = clamp((int)Math.ceil((box.maxX - region.getOriginX()) / cellSize), 0, subSX - 1);
+        int y1 = clamp((int)Math.ceil((box.maxY - region.getOriginY()) / cellSize), 0, subSY - 1);
+        int z1 = clamp((int)Math.ceil((box.maxZ - region.getOriginZ()) / cellSize), 0, subSZ - 1);
+
+        double sumVx = 0, sumVy = 0, sumVz = 0;
+        int fluidCells = 0;
+
+        for (int gz = z0; gz <= z1; gz++)
+        for (int gy = y0; gy <= y1; gy++)
+        for (int gx = x0; gx <= x1; gx++) {
+            int i = gx + gy * subSX + gz * subSX * subSY;
+            float v = vof[i];
+            if (v < FLUID_VOF_THRESHOLD) continue;
+            fluidCells++;
+            sumVx += vx[i] * v;
+            sumVy += vy[i] * v;
+            sumVz += vz[i] * v;
+        }
+
+        if (fluidCells == 0) return ForceResult.ZERO;
+
+        // 浮力（阿基米德）
+        float cellVol   = cellSize * cellSize * cellSize;   // 0.001 m³
+        float buoyancy  = fluidCells * cellVol * WATER_DENSITY * GRAVITY;
+
+        // 拖曳力（F_d = ½ρ Cd A |v_rel|·v_rel）
+        double invN  = 1.0 / fluidCells;
+        double avgVx = sumVx * invN;
+        double avgVy = sumVy * invN;
+        double avgVz = sumVz * invN;
+        double dragK = 0.5 * WATER_DENSITY * DRAG_CD * ENTITY_CROSS_AREA;
+
+        double fx = avgVx * Math.abs(avgVx) * dragK;
+        double fy = buoyancy + avgVy * Math.abs(avgVy) * dragK;
+        double fz = avgVz * Math.abs(avgVz) * dragK;
+
+        return new ForceResult((float)fx, (float)fy, (float)fz, fluidCells);
+    }
+
+    private static boolean overlapsRegion(AABB box, FluidRegion region) {
+        return box.maxX >= region.getOriginX()
+            && box.minX <= region.getOriginX() + region.getSizeX()
+            && box.maxY >= region.getOriginY()
+            && box.minY <= region.getOriginY() + region.getSizeY()
+            && box.maxZ >= region.getOriginZ()
+            && box.minZ <= region.getOriginZ() + region.getSizeZ();
+    }
+
+    private static double clampDv(double dv) {
+        return Math.max(-MAX_DV, Math.min(MAX_DV, dv));
+    }
+
+    private static int clamp(int v, int lo, int hi) {
+        return Math.max(lo, Math.min(hi, v));
+    }
+
+    /** 力計算結果（不可變記錄）。 */
+    private record ForceResult(float fx, float fy, float fz, int fluidCells) {
+        static final ForceResult ZERO = new ForceResult(0, 0, 0, 0);
+    }
+}

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/fluid/FluidRegion.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/fluid/FluidRegion.java
@@ -255,8 +255,10 @@ public class FluidRegion {
     /** 計算此區域中非空氣體素數量 */
     public int getFluidVoxelCount() {
         int count = 0;
+        int airId = FluidType.AIR.getId();
         for (int i = 0; i < totalVoxels; i++) {
-            if (volume[i] > FluidConstants.MIN_VOLUME_FRACTION && type[i] != FluidType.AIR.getId()) {
+            // & 0xFF：byte 轉無符號 int，避免 getId() > 127 時符號延伸造成比較錯誤
+            if (volume[i] > FluidConstants.MIN_VOLUME_FRACTION && (type[i] & 0xFF) != airId) {
                 count++;
             }
         }

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/fluid/FluidRegionRegistry.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/fluid/FluidRegionRegistry.java
@@ -109,12 +109,21 @@ public class FluidRegionRegistry {
 
     /**
      * 計算包含 pos 的區域 key。
-     * 使用區域原點的 packed long 作為唯一識別。
+     * 使用偏移後的 packed long 作為唯一識別。
+     *
+     * <p>原實作直接對負 rx/ry/rz 做位元遮罩（& 0x1FFFFF），
+     * 當座標為負時符號位延伸會污染高位元，導致負/正座標的 key 碰撞。
+     * 修正：加入偏移使所有值為非負，再遮罩；X/Z 偏移 2²¹ 支援 ±30M 世界邊界
+     * 在 regionSize≥16 下不溢位（max |rx|=1,875,000 < 2,097,151）。
      */
     private static long regionKey(BlockPos pos, int regionSize) {
         int rx = Math.floorDiv(pos.getX(), regionSize);
         int ry = Math.floorDiv(pos.getY(), regionSize);
         int rz = Math.floorDiv(pos.getZ(), regionSize);
-        return ((long) rx & 0x1FFFFF) << 42 | ((long) ry & 0x1FFFFF) << 21 | ((long) rz & 0x1FFFFF);
+        // 偏移後確保非負（X/Z 偏移 2^21, Y 偏移 2^9 足以容納 Minecraft 高度範圍）
+        long kx = ((long) rx + (1L << 21)) & 0x3FFFFFL; // 22 bits
+        long ky = ((long) ry + (1L <<  9)) & 0x3FFL;    // 10 bits
+        long kz = ((long) rz + (1L << 21)) & 0x3FFFFFL; // 22 bits
+        return (kx << 32) | (ky << 22) | kz;
     }
 }

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/fluid/FluidStructureCoupler.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/fluid/FluidStructureCoupler.java
@@ -61,7 +61,13 @@ public class FluidStructureCoupler {
         // 如果是 FluidGPUEngine，直接使用其快取
         if (manager instanceof FluidGPUEngine gpuEngine) {
             Map<BlockPos, Float> cache = gpuEngine.getBoundaryPressureCache();
-            pressureLookup = pos -> cache.getOrDefault(pos, 0f);
+            if (cache == null) {
+                pressureLookup = pos -> 0f;
+            } else {
+                // 快取參考在 lambda 建立時捕獲（不可變快照語意）。
+                // volatile pressureLookup 確保其他執行緒每次讀到最新 lambda 參考。
+                pressureLookup = pos -> cache.getOrDefault(pos, 0f);
+            }
         } else {
             // 通用路徑：逐位置查詢
             pressureLookup = manager::getFluidPressureAt;

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFDataBuilder.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFDataBuilder.java
@@ -31,8 +31,9 @@ public final class PFSFDataBuilder {
     /**
      * 計算並上傳 island 的 source、conductivity、type 等數據到 GPU。
      *
-     * @param curingLookup  ICuringManager 水化度查詢（null → 全部視為完全養護 1.0）
-     * @param windVec       全域風向向量（null → 不施加風壓偏置）
+     * @param curingLookup         ICuringManager 水化度查詢（null → 全部視為完全養護 1.0）
+     * @param windVec              全域風向向量（null → 不施加風壓偏置）
+     * @param fluidPressureLookup  流體邊界力查詢，單位 N（null → 不施加流體壓力）
      */
     static void updateSourceAndConductivity(PFSFIslandBuffer buf,
                                              StructureIsland island,
@@ -41,7 +42,8 @@ public final class PFSFDataBuilder {
                                              Function<BlockPos, Boolean> anchorLookup,
                                              Function<BlockPos, Float> fillRatioLookup,
                                              @Nullable Function<BlockPos, Float> curingLookup,
-                                             @Nullable Vec3 windVec) {
+                                             @Nullable Vec3 windVec,
+                                             @Nullable Function<BlockPos, Float> fluidPressureLookup) {
         Set<BlockPos> members = island.getMembers();
 
         Set<BlockPos> anchors = new HashSet<>();
@@ -124,6 +126,15 @@ public final class PFSFDataBuilder {
                     * PFSFConstants.GRAVITY * PFSFConstants.BLOCK_VOLUME);
             source[i] = baseWeight * momentFactor;
 
+            // 流體壓力耦合：將流體邊界力疊加到結構 source 項
+            // 單位一致（均為 N），正規化由下方 sigmaMax 統一處理
+            if (fluidPressureLookup != null) {
+                Float fp = fluidPressureLookup.apply(pos);
+                if (fp != null && fp > 0f) {
+                    source[i] += fp;
+                }
+            }
+
             type[i]   = anchors.contains(pos) ? VOXEL_ANCHOR : VOXEL_SOLID;
             // maxPhi 反映 G_c（gcScale）影響：養護不足 → maxPhi 降低 → 更容易斷裂
             maxPhi[i] = PFSFSourceBuilder.computeMaxPhiTimoshenko(mat, arm, sectionHeight) * gcScale;
@@ -203,7 +214,22 @@ public final class PFSFDataBuilder {
     }
 
     /**
-     * 向下相容：不含水化度/風向的舊 API。
+     * 向下相容：含水化度/風向但無流體壓力的 API。
+     */
+    static void updateSourceAndConductivity(PFSFIslandBuffer buf,
+                                             StructureIsland island,
+                                             ServerLevel level,
+                                             Function<BlockPos, RMaterial> materialLookup,
+                                             Function<BlockPos, Boolean> anchorLookup,
+                                             Function<BlockPos, Float> fillRatioLookup,
+                                             @Nullable Function<BlockPos, Float> curingLookup,
+                                             @Nullable Vec3 windVec) {
+        updateSourceAndConductivity(buf, island, level, materialLookup,
+                anchorLookup, fillRatioLookup, curingLookup, windVec, null);
+    }
+
+    /**
+     * 向下相容：不含水化度/風向/流體壓力的舊 API。
      */
     static void updateSourceAndConductivity(PFSFIslandBuffer buf,
                                              StructureIsland island,
@@ -212,7 +238,7 @@ public final class PFSFDataBuilder {
                                              Function<BlockPos, Boolean> anchorLookup,
                                              Function<BlockPos, Float> fillRatioLookup) {
         updateSourceAndConductivity(buf, island, level, materialLookup,
-                anchorLookup, fillRatioLookup, null, null);
+                anchorLookup, fillRatioLookup, null, null, null);
     }
 
     // ═══════════════════════════════════════════════════════════════

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFDispatcher.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFDispatcher.java
@@ -49,7 +49,7 @@ public final class PFSFDispatcher {
             // 全量重建
             PFSFDataBuilder.updateSourceAndConductivity(buf, ctx.island, ctx.level,
                     ctx.materialLookup, ctx.anchorLookup, ctx.fillRatioLookup,
-                    ctx.curingLookup, ctx.windVec);
+                    ctx.curingLookup, ctx.windVec, ctx.fluidPressureLookup);
             buf.markClean();
             return true;
         } else if (!updates.isEmpty()) {

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFEngine.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFEngine.java
@@ -141,14 +141,18 @@ public final class PFSFEngine {
         final Function<BlockPos, Float> fillRatioLookup;
         final Function<BlockPos, Float> curingLookup;
         final net.minecraft.world.phys.Vec3 windVec;
+        /** 流體壓力查詢（FluidStructureCoupler 提供；null = 無流體耦合）*/
+        final Function<BlockPos, Float> fluidPressureLookup;
 
         UploadContext(StructureIsland island, ServerLevel level,
                       Function<BlockPos, RMaterial> mat, Function<BlockPos, Boolean> anchor,
                       Function<BlockPos, Float> fill, Function<BlockPos, Float> curing,
-                      net.minecraft.world.phys.Vec3 wind) {
+                      net.minecraft.world.phys.Vec3 wind,
+                      Function<BlockPos, Float> fluidPressure) {
             this.island = island; this.level = level;
             this.materialLookup = mat; this.anchorLookup = anchor;
             this.fillRatioLookup = fill; this.curingLookup = curing; this.windVec = wind;
+            this.fluidPressureLookup = fluidPressure;
         }
     }
 }

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFEngineInstance.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFEngineInstance.java
@@ -221,7 +221,8 @@ public final class PFSFEngineInstance implements IPFSFRuntime {
 
             // Data upload
             PFSFEngine.UploadContext ctx = new PFSFEngine.UploadContext(island, level,
-                    materialLookup, anchorLookup, fillRatioLookup, curingLookup, currentWindVec);
+                    materialLookup, anchorLookup, fillRatioLookup, curingLookup, currentWindVec,
+                    com.blockreality.api.physics.fluid.FluidStructureCoupler.getPressureLookup());
             dispatcher.handleDataUpload(frame, buf, sparse, ctx, descriptorPool);
 
             // ─── v3: LOD 物理（距離分級）───

--- a/Block Reality/api/src/main/resources/assets/blockreality/shaders/compute/fluid/fluid_surface_normal.comp.glsl
+++ b/Block Reality/api/src/main/resources/assets/blockreality/shaders/compute/fluid/fluid_surface_normal.comp.glsl
@@ -1,0 +1,139 @@
+/**
+ * PFSF-Fluid: 速度梯度 → 像素法線擾動貼圖 Compute Shader
+ *
+ * 從 sub-cell 速度場計算速度梯度，輸出用於 BRWaterRenderer 法線混合的
+ * 擾動貼圖（256×256，R16G16B16A16_SFLOAT）。
+ *
+ * 輸入：
+ *   binding=0: vx[]  (sub-cell 速度 X，m/s)
+ *   binding=1: vy[]  (sub-cell 速度 Y，m/s)
+ *   binding=2: vz[]  (sub-cell 速度 Z，m/s)
+ *   binding=3: vof[] (Volume-of-Fluid 分率 [0,1])
+ *
+ * 輸出：
+ *   binding=4: normalMap（rgba16f image2D，256×256）
+ *              XY 通道：切向擾動法線（編碼為 [0,1]，中心 0.5 對應無擾動）
+ *              Z 通道：渦度量值（‖∇×v‖，歸一化）
+ *              W 通道：預留（1.0）
+ *
+ * 法線計算：
+ *   ∂vx/∂x ≈ (vx[i+1,j,k] - vx[i-1,j,k]) / (2 * cellSize)
+ *   ∂vz/∂z ≈ (vz[i,j,k+1] - vz[i,j,k-1]) / (2 * cellSize)
+ *   原始法線 = normalize((-∂vx/∂x, 1.0, -∂vz/∂z) * DETAIL_SCALE)
+ *   輸出 = normal * 0.5 + 0.5（解碼：normal = texel * 2.0 - 1.0）
+ *
+ * 渦度計算（Z 分量）：
+ *   ω_y = ∂vz/∂x - ∂vx/∂z（Y 軸渦度，對水面最重要）
+ *   ‖∇×v‖_norm = clamp(|ω_y| / VORTICITY_SCALE, 0, 1)
+ *
+ * 解析度映射：
+ *   輸出貼圖 256×256 對應 sub-cell 網格的 XZ 截面（中層 Y=subSY/2）。
+ *   sub-cell 尺寸 0.1m，每個 texel 對應一個 sub-cell（最多 256 格）。
+ *   網格尺寸 < 256 時，貼圖其餘部分填充中性法線（0.5, 0.5, 1.0）。
+ *
+ * @see BRWaterRenderer（消費此貼圖，60% Gerstner + 40% 物理法線混合）
+ * @version 1.0
+ */
+#version 450
+
+layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+
+// ─── Push Constants ───
+layout(push_constant) uniform PushConstants {
+    uint  subSX;          // sub-cell 網格 X 尺寸
+    uint  subSY;          // sub-cell 網格 Y 尺寸
+    uint  subSZ;          // sub-cell 網格 Z 尺寸
+    float cellSize;       // sub-cell 邊長（公尺，通常 0.1）
+    float detailScale;    // 法線擾動強度（建議 0.15）
+    float vorticityScale; // 渦度歸一化係數（建議 5.0，rad/s）
+};
+
+// ─── 輸入緩衝（sub-cell SoA，SSBO）───
+layout(std430, binding = 0) readonly buffer VxBuf   { float vx[]; };
+layout(std430, binding = 1) readonly buffer VyBuf   { float vy[]; };
+layout(std430, binding = 2) readonly buffer VzBuf   { float vz[]; };
+layout(std430, binding = 3) readonly buffer VofBuf  { float vof[]; };
+
+// ─── 輸出法線貼圖（rgba16f image2D）───
+layout(rgba16f, binding = 4) writeonly uniform image2D normalMap;
+
+// ─── 常數 ───
+const float MIN_VOF      = 0.1;   // VOF < 此值視為空氣
+const float NEUTRAL_NX   = 0.5;   // 無擾動法線 X（[0,1] 編碼）
+const float NEUTRAL_NY   = 0.5;   // 無擾動法線 Y（[0,1] 編碼）
+const float NEUTRAL_NZ   = 1.0;   // 無擾動法線 Z（直上）
+
+// ─── 工具函數 ───
+
+/** sub-cell 平坦索引（Y 取中層截面 midY） */
+uint flatIdx(uint gx, uint midY, uint gz) {
+    return gx + midY * subSX + gz * subSX * subSY;
+}
+
+/** 安全取 vx（邊界 clamp） */
+float sampleVx(int gx, int midY, int gz) {
+    int x = clamp(gx, 0, int(subSX) - 1);
+    int z = clamp(gz, 0, int(subSZ) - 1);
+    return vx[uint(x) + uint(midY) * subSX + uint(z) * subSX * subSY];
+}
+
+float sampleVz(int gx, int midY, int gz) {
+    int x = clamp(gx, 0, int(subSX) - 1);
+    int z = clamp(gz, 0, int(subSZ) - 1);
+    return vz[uint(x) + uint(midY) * subSX + uint(z) * subSX * subSY];
+}
+
+void main() {
+    // 輸出貼圖座標（256×256）
+    ivec2 texCoord = ivec2(gl_GlobalInvocationID.xy);
+    if (texCoord.x >= 256 || texCoord.y >= 256) return;
+
+    // 貼圖 texel → sub-cell (gx, gz) 對應（texCoord.y → gz）
+    int gx = texCoord.x;
+    int gz = texCoord.y;
+
+    // 超出 sub-cell 範圍 → 輸出中性法線
+    if (uint(gx) >= subSX || uint(gz) >= subSZ) {
+        imageStore(normalMap, texCoord, vec4(NEUTRAL_NX, NEUTRAL_NY, NEUTRAL_NZ, 1.0));
+        return;
+    }
+
+    // 取水面中層 Y（最接近自由表面的 sub-cell 層）
+    int midY = int(subSY) / 2;
+
+    // VOF 為空氣 → 輸出中性法線
+    uint centerIdx = flatIdx(uint(gx), uint(midY), uint(gz));
+    if (vof[centerIdx] < MIN_VOF) {
+        imageStore(normalMap, texCoord, vec4(NEUTRAL_NX, NEUTRAL_NY, NEUTRAL_NZ, 1.0));
+        return;
+    }
+
+    // ─── 速度梯度計算（中心差分） ───
+    float inv2h = 1.0 / (2.0 * cellSize);
+
+    float dvxdx = (sampleVx(gx + 1, midY, gz) - sampleVx(gx - 1, midY, gz)) * inv2h;
+    float dvzdz = (sampleVz(gx, midY, gz + 1) - sampleVz(gx, midY, gz - 1)) * inv2h;
+
+    // ─── 渦度 Y 分量（∂vz/∂x - ∂vx/∂z） ───
+    float dvzdx = (sampleVz(gx + 1, midY, gz) - sampleVz(gx - 1, midY, gz)) * inv2h;
+    float dvxdz = (sampleVx(gx, midY, gz + 1) - sampleVx(gx, midY, gz - 1)) * inv2h;
+    float vortY  = dvzdx - dvxdz;
+
+    // ─── 法線擾動（速度梯度投影到水面切平面） ───
+    // 法線近似：(x, y, z) = normalize(-∂vx/∂x, 1/detailScale, -∂vz/∂z)
+    vec3 rawNormal = vec3(-dvxdx * detailScale, 1.0, -dvzdz * detailScale);
+    vec3 n = normalize(rawNormal);
+
+    // 渦度歸一化到 [0,1]
+    float vortNorm = clamp(abs(vortY) / vorticityScale, 0.0, 1.0);
+
+    // 編碼到 [0,1]（供 BRWaterRenderer 解碼：normal = texel * 2.0 - 1.0）
+    vec4 encoded = vec4(
+        n.x * 0.5 + 0.5,
+        n.z * 0.5 + 0.5,  // Z → texel G（Y 軸朝上，xz 為水平面）
+        vortNorm,
+        1.0
+    );
+
+    imageStore(normalMap, texCoord, encoded);
+}

--- a/Block Reality/fastdesign/src/main/java/com/blockreality/fastdesign/client/node/impl/render/water/WaterCausticsNode.java
+++ b/Block Reality/fastdesign/src/main/java/com/blockreality/fastdesign/client/node/impl/render/water/WaterCausticsNode.java
@@ -1,5 +1,6 @@
 package com.blockreality.fastdesign.client.node.impl.render.water;
 
+import com.blockreality.api.client.render.effect.BRWaterRenderer;
 import com.blockreality.fastdesign.client.node.*;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.api.distmarker.Dist;
@@ -21,6 +22,11 @@ public class WaterCausticsNode extends BRNode {
 
     @Override
     public void evaluate() {
+        float vel = getInput("fluidVelocity").getFloat();  // 0-10 m/s
+        float baseSpeed = getInput("speed").getFloat();
+        // 高流速 → 焦散動畫加速（最多 5× 於 10 m/s）
+        float speedMult = 1.0f + vel * 0.4f;
+        BRWaterRenderer.setCausticsAnimSpeed(baseSpeed * speedMult);
         getOutput("waterCausticsIntensity").setValue(getInput("intensity").getFloat());
     }
 

--- a/Block Reality/fastdesign/src/main/java/com/blockreality/fastdesign/client/node/impl/render/water/WaterFoamNode.java
+++ b/Block Reality/fastdesign/src/main/java/com/blockreality/fastdesign/client/node/impl/render/water/WaterFoamNode.java
@@ -20,7 +20,11 @@ public class WaterFoamNode extends BRNode {
 
     @Override
     public void evaluate() {
-        getOutput("waterFoamThreshold").setValue(getInput("threshold").getFloat());
+        float baseThr = getInput("threshold").getFloat();
+        float turbulence = getInput("fluidTurbulence").getFloat();
+        // 高渦度 → 泡沫閾值降低（更容易起泡）
+        float effectiveThr = baseThr / (1.0f + turbulence * 2.0f);
+        getOutput("waterFoamThreshold").setValue(effectiveThr);
     }
 
     @Override public String getTooltip() { return "水面泡沫閾值、消退速度與顏色"; }


### PR DESCRIPTION
物理→視覺回饋鏈三個斷點全部修復並新增像素級細節效果：

斷點修復（Phase 2）：
- BRWaterRenderer: FOAM/CAUSTICS 常數 final → volatile，新增物理狀態欄位 (physicsVelocityMagnitude / physicsCompressionRatio / causticsAnimSpeedMult)
- computeWaveHeight/Normal: physicsVelocityMagnitude 驅動 Gerstner 波振幅（最多 +30%）
- FluidRenderBridge.onClientTick(): 從活動 FluidRegion 提取最大速度量值與壓力， 推送至 BRWaterRenderer.setPhysicsVelocityMagnitude/setPhysicsCompressionRatio
- WaterFoamNode.evaluate(): fluidTurbulence 驅動閾值降低（thr / (1 + turb * 2)）
- WaterCausticsNode.evaluate(): fluidVelocity 驅動焦散動畫速度 (BRWaterRenderer.setCausticsAnimSpeed(baseSpeed * (1 + vel * 0.4)))

像素細節效果（Phase 3）：
- setupWaterUniforms(): 高壓時水色線性插值至淡藍白（pressureRatio 驅動 compressionTint）
- FluidSplashEmitter.emitCompressionWave(): 壓力 > 4 atm → 8~12 顆 BUBBLE 粒子 向四周擴散（10 tick 冷卻）
- 新增 fluid_surface_normal.comp.glsl: 速度梯度 → 256×256 像素法線擾動貼圖 (XZ 梯度 → 切向法線；渦度 Y 分量 → W 通道；DETAIL_SCALE 0.15)
- BRWaterRenderer: physicsNormalMapTex 綁定 GL_TEXTURE5， u_physicsNormalBlend=0.4（60% Gerstner + 40% 物理法線）

