### PR TITLE
fix(lwjgl): M6 — patch Library.class null classloader via ASM

### DIFF
--- a/Block Reality/api/build.gradle
+++ b/Block Reality/api/build.gradle
@@ -1,3 +1,25 @@
+// ═══ Buildscript: ASM for Library.class bytecode patching ═══
+// ASM is needed to patch org.lwjgl.system.Library.findResource() to handle
+// null classloader (which occurs when Library is loaded by bootstrap CL via
+// -Xbootclasspath/a:). The patched jar is listed FIRST in the boot classpath
+// so the JVM uses our version, preventing ExceptionInInitializerError.
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'org.ow2.asm:asm:9.6'
+        classpath 'org.ow2.asm:asm-commons:9.6'
+    }
+}
+
+import org.objectweb.asm.ClassReader
+import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.Label
+import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.Opcodes
+
 plugins {
     id 'java'
     id 'eclipse'
@@ -34,18 +56,19 @@ minecraft {
 //  LWJGL Vulkan / VMA / Shaderc 嵌入（Forge 1.20.1 不含這些模組）
 // ═══════════════════════════════════════════════════════════════════
 //
-//  ★ 根本原因：Forge 的 TransformingClassLoader 將所有 org.lwjgl.*
-//    的類查找委託給父類載入器（系統 classpath）。
-//    即使 lwjgl-vulkan.jar 在 runtimeClasspath 或 shade 進 mod jar，
-//    mod 的類載入器也不會在自己的路徑中搜索 org.lwjgl.vulkan.VK。
+//  ★ 根本問題（M6 最終修正）：
+//    - -Xbootclasspath/a: 讓 Forge TCL 可找到 org.lwjgl.vulkan.*
+//    - 但 Library.class 被 bootstrap classloader 載入 → getClassLoader() 回傳 null
+//    - Library.findResource() 直接呼叫 null.getResource() → NPE → ExceptionInInitializerError
 //
 //  ★ 解決方案：
-//    runClient/runServer  → -Xbootclasspath/a: 加入 boot classpath
-//    生產部署（mod jar）  → JarInJar（FG6 原生） + native .dll/.so shade
-//
-//  ★ LWJGL 版本：3.3.1（匹配 Minecraft 內建 lwjgl-core，消除跨版本風險）
-//  ★ -Xbootclasspath/a: 在 Java 17 仍受支援（只有 -Xbootclasspath: 被移除）
-//  ★ 不需要 C++ 外掛程式 — LWJGL 透過 JNI 橋接 Vulkan driver
+//    1. patchLwjglLibrary task：用 ASM 修補 Library.class，
+//       在每個 Class.getClassLoader() 呼叫後加入 null check，
+//       null 時改用 Thread.currentThread().getContextClassLoader()
+//    2. 修補後的 jar（lwjgl-core-patched.jar）列在 -Xbootclasspath/a: 最前面，
+//       JVM 優先找到修補版本
+//    3. findResource() 返回 null（沒有 NPE）→ loadSystem() 改用
+//       System.loadLibrary("vulkan-1") → 從系統 PATH 找到 vulkan-1.dll → 成功！
 // ═══════════════════════════════════════════════════════════════════
 
 configurations {
@@ -61,7 +84,8 @@ dependencies {
     implementation "org.lwjgl:lwjgl-shaderc:3.3.1"
 
     // ★ lwjglBootstrap — runClient/runServer 時注入 boot classpath
-    //   主 API jar（純 Java 綁定）
+    //   ★ 重要：必須包含 lwjgl core（org.lwjgl.system.Configuration 所在 jar）
+    lwjglBootstrap "org.lwjgl:lwjgl:3.3.1"          // ★ CORE — org.lwjgl.system.*（Configuration, MemoryStack 等）
     lwjglBootstrap "org.lwjgl:lwjgl-vulkan:3.3.1"
     lwjglBootstrap "org.lwjgl:lwjgl-vma:3.3.1"
     lwjglBootstrap "org.lwjgl:lwjgl-shaderc:3.3.1"
@@ -76,10 +100,6 @@ dependencies {
 
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
 
-    // Valkyrien Skies 2 integration is fully reflection-based (no compile-time dependency).
-    // VS2 detection at runtime via ModList.isLoaded("valkyrienskies").
-    // See VS2ShipBridge.java for the reflective API calls.
-
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.3'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.3'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.9.3'
@@ -91,16 +111,140 @@ test {
     useJUnitPlatform()
 }
 
-// ═══ runClient / runServer：boot classpath 注入 ═══
-// FG6 的 run 任務為 JavaExec 類型，afterEvaluate 確保 FG6 已建立後才修改。
-// -Xbootclasspath/a: 將 LWJGL jar 加入 boot classpath，繞過 Forge 的
-// TransformingClassLoader 對 org.lwjgl.* 的父類委託限制。
-afterEvaluate {
-    def lwjglJars = configurations.lwjglBootstrap.resolve()
-    tasks.withType(JavaExec).configureEach { task ->
-        lwjglJars.each { file ->
-            task.jvmArgs "-Xbootclasspath/a:${file.absolutePath}"
+// ═══════════════════════════════════════════════════════════════════
+//  patchLwjglLibrary：修補 Library.class 以處理 bootstrap CL null
+// ═══════════════════════════════════════════════════════════════════
+// 根本原因：當 Library.class 透過 -Xbootclasspath/a: 被 bootstrap classloader 載入時，
+// Library.class.getClassLoader() 返回 null（bootstrap CL 無 Java 物件）。
+// Library.findResource() 直接在 null 上呼叫 .getResource() → NPE。
+//
+// 修補策略（ASM 位元組碼轉換）：
+//   在 Library.class 的所有方法中，每個 INVOKEVIRTUAL Class.getClassLoader() 指令後，
+//   插入 null check：若結果為 null，改用 Thread.currentThread().getContextClassLoader()。
+//   這樣 findResource() 返回 null（找不到資源），loadSystem() 改走 System.loadLibrary()。
+//
+// 輸出：libs/lwjgl-core-patched.jar（僅含修補後的 Library.class）
+// ═══════════════════════════════════════════════════════════════════
+task patchLwjglLibrary {
+    def patchedJarFile = file("${rootDir}/libs/lwjgl-core-patched.jar")
+    outputs.file(patchedJarFile)
+
+    doLast {
+        // 1. 取得原始 lwjgl-3.3.1.jar（CORE）
+        def originalJar = configurations.lwjglBootstrap.resolvedConfiguration.resolvedArtifacts
+            .find { it.name == 'lwjgl' && it.extension == 'jar' && it.classifier == null }?.file
+
+        if (originalJar == null || !originalJar.exists()) {
+            throw new GradleException("[BR-Patch] 找不到 lwjgl-3.3.1.jar（CORE）於 lwjglBootstrap 組態中")
         }
+
+        logger.lifecycle("[BR-Patch] 正在修補 Library.class，來源：${originalJar}")
+
+        // 2. 從 jar 中提取 Library.class 位元組
+        byte[] classBytes
+        new java.util.zip.ZipFile(originalJar).withCloseable { zip ->
+            def entry = zip.getEntry('org/lwjgl/system/Library.class')
+            if (entry == null) {
+                throw new GradleException("[BR-Patch] Library.class 未在 ${originalJar} 中找到")
+            }
+            classBytes = zip.getInputStream(entry).bytes
+        }
+
+        // 3. 用 ASM 修補 Library.class
+        def cr = new ClassReader(classBytes)
+        // COMPUTE_FRAMES 自動重算 stack map frames（需覆寫 getCommonSuperclass 以避免 CL 問題）
+        def cw = new ClassWriter(cr, ClassWriter.COMPUTE_FRAMES) {
+            String getCommonSuperclass(String type1, String type2) {
+                try {
+                    return super.getCommonSuperclass(type1, type2)
+                } catch (Exception ignored) {
+                    return 'java/lang/Object'
+                }
+            }
+        }
+
+        // ClassVisitor：攔截所有方法，修補其中的 Class.getClassLoader() 呼叫
+        cr.accept(new ClassVisitor(Opcodes.ASM9, cw) {
+            MethodVisitor visitMethod(int access, String name, String desc,
+                                     String signature, String[] exceptions) {
+                def mv = super.visitMethod(access, name, desc, signature, exceptions)
+
+                // MethodVisitor：在每個 Class.getClassLoader() INVOKEVIRTUAL 後插入 null check
+                return new MethodVisitor(Opcodes.ASM9, mv) {
+                    void visitMethodInsn(int opcode, String owner, String mName,
+                                        String mDesc, boolean isInterface) {
+                        // 先執行原本的 INVOKEVIRTUAL（或其他）指令
+                        super.visitMethodInsn(opcode, owner, mName, mDesc, isInterface)
+
+                        // 若剛才執行的是 Class.getClassLoader()，在其後加入 null check
+                        if (opcode == Opcodes.INVOKEVIRTUAL
+                                && 'java/lang/Class' == owner
+                                && 'getClassLoader' == mName
+                                && '()Ljava/lang/ClassLoader;' == mDesc) {
+
+                            // 此時 stack 頂端是 ClassLoader（可能為 null）
+                            // 生成：if (cl == null) cl = Thread.currentThread().getContextClassLoader()
+                            //
+                            // 位元組碼序列：
+                            //   DUP                           → stack: [cl, cl]
+                            //   IFNONNULL skip                → 若非 null 跳到 skip；stack: [cl]
+                            //   POP                           → 丟棄 null；stack: []
+                            //   INVOKESTATIC Thread.currentThread()   → stack: [thread]
+                            //   INVOKEVIRTUAL Thread.getContextClassLoader() → stack: [cl2]
+                            //   skip:                         → stack: [cl (非 null)]
+
+                            Label skip = new Label()
+                            super.visitInsn(Opcodes.DUP)
+                            super.visitJumpInsn(Opcodes.IFNONNULL, skip)
+                            super.visitInsn(Opcodes.POP)
+                            super.visitMethodInsn(Opcodes.INVOKESTATIC,
+                                'java/lang/Thread', 'currentThread',
+                                '()Ljava/lang/Thread;', false)
+                            super.visitMethodInsn(Opcodes.INVOKEVIRTUAL,
+                                'java/lang/Thread', 'getContextClassLoader',
+                                '()Ljava/lang/ClassLoader;', false)
+                            super.visitLabel(skip)
+                        }
+                    }
+                }
+            }
+        }, 0)
+
+        // 4. 寫出僅含修補後 Library.class 的 jar
+        patchedJarFile.parentFile.mkdirs()
+        new java.util.zip.ZipOutputStream(patchedJarFile.newOutputStream()).withCloseable { zos ->
+            zos.putNextEntry(new java.util.zip.ZipEntry('org/lwjgl/system/Library.class'))
+            zos.write(cw.toByteArray())
+            zos.closeEntry()
+        }
+
+        logger.lifecycle("[BR-Patch] ✓ 修補完成：${patchedJarFile}")
+        logger.lifecycle("[BR-Patch]   原始大小：${classBytes.length} bytes → 修補後：${cw.toByteArray().length} bytes")
+    }
+}
+
+// ═══ runClient / runServer：-Xbootclasspath/a: 注入 ═══
+// ★ 修補策略（M6）：
+//   -Xbootclasspath/a: 讓 Forge TCL → Module Layer → Bootstrap 委派鏈能找到 LWJGL。
+//   修補後的 lwjgl-core-patched.jar 列在最前面，使 JVM 優先使用修補版 Library.class。
+//   修補版的 Library.findResource() 在 bootstrap CL null 情況下不拋 NPE，
+//   而是返回 null → loadSystem() 改用 System.loadLibrary() → 系統 vulkan-1.dll。
+//
+// FG6 的 run 任務為 JavaExec 類型，afterEvaluate 確保 FG6 已建立後才修改。
+afterEvaluate {
+    def patchedJarPath = file("${rootDir}/libs/lwjgl-core-patched.jar").absolutePath
+
+    // 收集所有 lwjglBootstrap jar 的路徑（patched jar 排在第一）
+    def bootstrapJarPaths = [patchedJarPath] +
+        configurations.lwjglBootstrap.resolve().collect { it.absolutePath }
+    def bootCP = bootstrapJarPaths.join(File.pathSeparator)
+
+    tasks.withType(JavaExec).configureEach { task ->
+        // 確保 patched jar 存在（先執行 patchLwjglLibrary）
+        task.dependsOn(patchLwjglLibrary)
+        // 注入 boot classpath：patched jar 第一，其餘 LWJGL jar 隨後
+        task.jvmArgs("-Xbootclasspath/a:${bootCP}")
+        logger.info("[BR-api] boot classpath 注入：${bootCP}")
     }
 }
 

--- a/Block Reality/fastdesign/build.gradle
+++ b/Block Reality/fastdesign/build.gradle
@@ -47,15 +47,31 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.2'
 }
 
-// ═══ LWJGL boot classpath 注入（複用 :api 的 lwjglBootstrap 配置）═══
-// fastdesign:runClient 也載入 blockreality 模組（含 VulkanComputeContext），
-// 所以也需要將 LWJGL jar 加入 boot classpath。
+// ═══ runClient / runServer：-Xbootclasspath/a: 注入（複用 :api 的 lwjglBootstrap 配置）═══
+// ★ M6 修正：
+//   使用 -Xbootclasspath/a: 而非 task.classpath()。
+//   原因：task.classpath() 將 jar 加到 AppClassLoader，但 Forge ModLauncher 的委派鏈為
+//   Bootstrap → Module Layer → TransformingClassLoader，AppClassLoader 不在其中，
+//   因此 VK 類別找不到（NoClassDefFoundError）。
+//
+//   -Xbootclasspath/a: 讓 org.lwjgl.vulkan.* 對 Forge 委派鏈可見。
+//   修補後的 lwjgl-core-patched.jar 排第一，覆寫 Library.class 以修正 null CL 問題。
+//
+// FG6 的 run 任務為 JavaExec 類型，afterEvaluate 確保 FG6 已建立後才修改。
 afterEvaluate {
-    def lwjglJars = project(':api').configurations.lwjglBootstrap.resolve()
+    def patchedJarPath = file("${rootProject.rootDir}/libs/lwjgl-core-patched.jar").absolutePath
+
+    // 收集所有 lwjglBootstrap jar 的路徑（patched jar 排在第一）
+    def bootstrapJarPaths = [patchedJarPath] +
+        project(':api').configurations.lwjglBootstrap.resolve().collect { it.absolutePath }
+    def bootCP = bootstrapJarPaths.join(File.pathSeparator)
+
     tasks.withType(JavaExec).configureEach { task ->
-        lwjglJars.each { file ->
-            task.jvmArgs "-Xbootclasspath/a:${file.absolutePath}"
-        }
+        // 確保 Library.class 已修補（先執行 :api:patchLwjglLibrary）
+        task.dependsOn(':api:patchLwjglLibrary')
+        // 注入 boot classpath：patched jar 第一，其餘 LWJGL jar 隨後
+        task.jvmArgs("-Xbootclasspath/a:${bootCP}")
+        logger.info("[BR-fastdesign] boot classpath 注入：${bootCP}")
     }
 }
 


### PR DESCRIPTION
Root cause (chain of two failures):
- task.classpath() → VK class not found (AppClassLoader not in Forge ModLauncher chain: Bootstrap → Module Layer → TransformingClassLoader)
- -Xbootclasspath/a: → VK class found, BUT Library.class is loaded by bootstrap CL → Library.class.getClassLoader() returns null → null.getResource(name) → NPE → ExceptionInInitializerError in Library.<clinit>

Fix:
Add patchLwjglLibrary Gradle task to api/build.gradle (ASM 9.6). The task extracts Library.class from lwjgl-3.3.1.jar and instruments every INVOKEVIRTUAL Class.getClassLoader() with a null-check:

  before: Class.getClassLoader() → null → NPE
  after:  Class.getClassLoader() → null
          → Thread.currentThread().getContextClassLoader() (Forge TCL, non-null)
          → findResource() returns null cleanly
          → loadSystem() falls back to System.loadLibrary("vulkan-1")
          → loads C:\Windows\System32\vulkan-1.dll ✓

Patched Library.class → libs/lwjgl-core-patched.jar (listed FIRST in -Xbootclasspath/a: so JVM picks patched version over lwjgl-3.3.1.jar). Both build.gradle afterEvaluate blocks revert from task.classpath() to -Xbootclasspath/a: and depend on :api:patchLwjglLibrary.

Expected: VK.create() → VkInstance → RTX 5070 Ti detected → "Vulkan RT 初始化完成 — NVIDIA GeForce RTX 5070 Ti Laptop GPU" ✓