### PR TITLE
v0.3c Phase 1: activate libpfsf JNI bridge scaffolding

### DIFF
--- a/Block Reality/api/build.gradle
+++ b/Block Reality/api/build.gradle
@@ -586,7 +586,7 @@ task nativeBuild(dependsOn: nativeConfigure) {
 // Surface staged natives to processResources so the final jar carries
 // them under META-INF/native/<triple>/. Only active when the flag is on;
 // otherwise processResources is unchanged so normal dev builds skip CMake.
-if (Boolean.parseBoolean(findProperty('blockreality.native.build') ?: 'false')) {
+if (cmakeExecutable != null && Boolean.parseBoolean(findProperty('blockreality.native.build') ?: 'false')) {
     processResources {
         dependsOn nativeBuild
         from(nativeOutputRoot) { include 'META-INF/native/**' }

--- a/Block Reality/api/build.gradle
+++ b/Block Reality/api/build.gradle
@@ -562,7 +562,7 @@ task nativeBuild(dependsOn: nativeConfigure) {
     doLast {
         project.exec {
             workingDir buildDir
-            commandLine cmakeExecutable, '--build', '.', '--parallel', '--target', 'blockreality_pfsf'
+            commandLine cmakeExecutable, '--build', '.', '--parallel', '--config', 'Release', '--target', 'blockreality_pfsf'
         }
         stageDir.mkdirs()
         def artifactPatterns = ['libblockreality_pfsf.so',

--- a/Block Reality/api/build.gradle
+++ b/Block Reality/api/build.gradle
@@ -489,3 +489,106 @@ task copyToDevInstance(type: Copy, dependsOn: jar) {
     into "$prismBase/instances/BR-Dev/.minecraft/mods/"
     rename { 'block-reality-api.jar' }
 }
+
+// ═══════════════════════════════════════════════════════════════════
+//  v0.3c — Native library build integration (libblockreality_pfsf …)
+// ═══════════════════════════════════════════════════════════════════
+// Sources live under L1-native/libpfsf. CMake configures once into
+// build/native-build and emits the shared library into build/native-out
+// under META-INF/native/<triple>/ so processResources picks it up and
+// the final mod jar ships a loadable blockreality_pfsf for the host
+// platform. Cross-platform CI matrix merges triples in the release job.
+// The tasks are no-ops when the flag is off or CMake is unavailable so
+// developer builds on machines without CMake keep working.
+
+def nativeBuildRoot  = layout.buildDirectory.dir('native-build')
+def nativeOutputRoot = layout.buildDirectory.dir('native-out')
+
+def currentNativeTriple = {
+    def os   = System.getProperty('os.name').toLowerCase(java.util.Locale.ROOT)
+    def arch = System.getProperty('os.arch').toLowerCase(java.util.Locale.ROOT)
+    if (os.contains('win'))    return arch.contains('aarch64') ? 'win-arm64'   : 'win-x64'
+    if (os.contains('mac'))    return arch.contains('aarch64') ? 'mac-arm64'   : 'mac-x64'
+    return arch.contains('aarch64') ? 'linux-arm64' : 'linux-x64'
+}()
+
+def cmakeExecutable = {
+    def candidates = System.getProperty('os.name').toLowerCase(java.util.Locale.ROOT).contains('win')
+            ? ['cmake.exe', 'cmake']
+            : ['cmake']
+    for (c in candidates) {
+        try {
+            def p = new ProcessBuilder(c, '--version').redirectErrorStream(true).start()
+            p.waitFor(); if (p.exitValue() == 0) return c
+        } catch (Throwable ignored) {}
+    }
+    return null
+}()
+
+task nativeConfigure {
+    description = 'Configures CMake for libblockreality_pfsf (v0.3c).'
+    group = 'native'
+    onlyIf { cmakeExecutable != null && Boolean.parseBoolean(findProperty('blockreality.native.build') ?: 'false') }
+
+    def buildDir = nativeBuildRoot.get().asFile
+    def sourceDir = file("${rootDir}/../L1-native/libpfsf")
+
+    inputs.file file("${sourceDir}/CMakeLists.txt")
+    outputs.dir buildDir
+
+    doLast {
+        buildDir.mkdirs()
+        project.exec {
+            workingDir buildDir
+            commandLine cmakeExecutable, '-S', sourceDir.absolutePath, '-B', '.',
+                    '-DCMAKE_BUILD_TYPE=Release',
+                    '-DPFSF_BUILD_JNI=ON',
+                    '-DPFSF_BUILD_EXAMPLE=OFF'
+        }
+    }
+}
+
+task nativeBuild(dependsOn: nativeConfigure) {
+    description = 'Builds libblockreality_pfsf and stages it under META-INF/native/<triple>/.'
+    group = 'native'
+    onlyIf { cmakeExecutable != null && Boolean.parseBoolean(findProperty('blockreality.native.build') ?: 'false') }
+
+    def buildDir  = nativeBuildRoot.get().asFile
+    def stageBase = nativeOutputRoot.get().asFile
+    def stageDir  = new File(stageBase, "META-INF/native/${currentNativeTriple}")
+
+    outputs.dir stageDir
+
+    doLast {
+        project.exec {
+            workingDir buildDir
+            commandLine cmakeExecutable, '--build', '.', '--parallel', '--target', 'blockreality_pfsf'
+        }
+        stageDir.mkdirs()
+        def artifactPatterns = ['libblockreality_pfsf.so',
+                                 'libblockreality_pfsf.dylib',
+                                 'blockreality_pfsf.dll']
+        def copied = 0
+        fileTree(buildDir).matching { include artifactPatterns }.files.each { src ->
+            project.copy {
+                from src
+                into stageDir
+            }
+            copied++
+            logger.lifecycle("[nativeBuild] staged ${src.name} → ${stageDir}")
+        }
+        if (copied == 0) {
+            logger.warn("[nativeBuild] no blockreality_pfsf artifact produced in ${buildDir}")
+        }
+    }
+}
+
+// Surface staged natives to processResources so the final jar carries
+// them under META-INF/native/<triple>/. Only active when the flag is on;
+// otherwise processResources is unchanged so normal dev builds skip CMake.
+if (Boolean.parseBoolean(findProperty('blockreality.native.build') ?: 'false')) {
+    processResources {
+        dependsOn nativeBuild
+        from(nativeOutputRoot) { include 'META-INF/native/**' }
+    }
+}

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/NativePFSFBridge.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/NativePFSFBridge.java
@@ -36,8 +36,8 @@ public final class NativePFSFBridge {
         String  version = "n/a";
         try {
             System.loadLibrary("blockreality_pfsf");
-            loaded  = true;
             version = nativeVersion();
+            loaded  = true;
             LOGGER.info("NativePFSFBridge loaded: blockreality_pfsf v{} ready", version);
         } catch (UnsatisfiedLinkError e) {
             // Expected when the native binary is absent (developer builds,

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/NativePFSFBridge.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/NativePFSFBridge.java
@@ -1,0 +1,170 @@
+package com.blockreality.api.physics.pfsf;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * JNI wrapper for the v0.3c native PFSF runtime ({@code libblockreality_pfsf}).
+ *
+ * <p>This class provides low-level access to the C API declared in
+ * {@code L1-native/libpfsf/include/pfsf/pfsf.h}. It is intentionally thin —
+ * higher-level Java callers should go through {@link NativePFSFRuntime},
+ * which wraps the handle lifecycle and applies the same callback/logging
+ * discipline as the existing Java solver.</p>
+ *
+ * <p>If {@code System.loadLibrary("blockreality_pfsf")} fails (shared library
+ * not on {@code java.library.path} or missing Vulkan SDK on the host),
+ * {@link #isAvailable()} returns {@code false} and calling any {@code native*}
+ * method is a programming error. Upstream code MUST check availability and
+ * fall back to the existing Java path — this mirrors the
+ * {@link com.blockreality.api.client.render.rt.BRNRDNative} pattern.</p>
+ *
+ * <p>Activation flag: {@code -Dblockreality.native.pfsf=true}. The loader
+ * still attempts {@code loadLibrary} regardless, so operators can eagerly
+ * detect native availability and report it, but the Java façade refuses
+ * to delegate unless the flag is explicitly set (Phase 1 safety posture).</p>
+ */
+public final class NativePFSFBridge {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("PFSF-Native");
+
+    private static final boolean LIBRARY_LOADED;
+    private static final String  VERSION_STRING;
+
+    static {
+        boolean loaded = false;
+        String  version = "n/a";
+        try {
+            System.loadLibrary("blockreality_pfsf");
+            loaded  = true;
+            version = nativeVersion();
+            LOGGER.info("NativePFSFBridge loaded: blockreality_pfsf v{} ready", version);
+        } catch (UnsatisfiedLinkError e) {
+            // Expected when the native binary is absent (developer builds,
+            // unsupported platforms, or when the operator hasn't run :api:nativeBuild).
+            LOGGER.info("NativePFSFBridge skipped: blockreality_pfsf not found — Java solver will be used. ({})",
+                    e.getMessage());
+        } catch (Throwable t) {
+            LOGGER.warn("NativePFSFBridge failed to initialise: {}", t.toString());
+        }
+        LIBRARY_LOADED = loaded;
+        VERSION_STRING = version;
+    }
+
+    private NativePFSFBridge() {}
+
+    /** @return whether {@code libblockreality_pfsf} loaded successfully. */
+    public static boolean isAvailable() {
+        return LIBRARY_LOADED;
+    }
+
+    /** Native library version string ({@code "0.1.0"} etc.), or {@code "n/a"} if unloaded. */
+    public static String getVersion() {
+        return VERSION_STRING;
+    }
+
+    // ── Native entry points (all jlong handles are opaque pfsf_engine) ──────
+
+    /** Creates a new engine handle. Returns {@code 0} on allocation failure. */
+    public static native long nativeCreate(int maxIslandSize,
+                                            int tickBudgetMs,
+                                            long vramBudgetBytes,
+                                            boolean enablePhaseField,
+                                            boolean enableMultigrid);
+
+    /** Initialises Vulkan + pipelines. Returns a {@link PFSFResult} code. */
+    public static native int nativeInit(long handle);
+
+    public static native void nativeShutdown(long handle);
+
+    public static native void nativeDestroy(long handle);
+
+    public static native boolean nativeIsAvailable(long handle);
+
+    /**
+     * Thread-safe stats query.
+     *
+     * @return {@code long[5]} = {@code {islandCount, totalVoxels, vramUsed,
+     *         vramBudget, lastTickMicros}} or {@code null} on failure.
+     */
+    public static native long[] nativeGetStats(long handle);
+
+    public static native void nativeSetWind(long handle, float wx, float wy, float wz);
+
+    public static native int nativeAddIsland(long handle,
+                                              int islandId,
+                                              int originX, int originY, int originZ,
+                                              int lx, int ly, int lz);
+
+    public static native void nativeRemoveIsland(long handle, int islandId);
+
+    public static native void nativeMarkFullRebuild(long handle, int islandId);
+
+    /**
+     * Registers a sparse voxel update.
+     *
+     * @param cond6 conductivity in the 6-direction SoA order (see
+     *              {@code pfsf_direction}). Length must be ≥ 6.
+     */
+    public static native int nativeNotifyBlockChange(long handle,
+                                                      int islandId,
+                                                      int flatIndex,
+                                                      float source,
+                                                      int voxelType,
+                                                      float maxPhi,
+                                                      float rcomp,
+                                                      float[] cond6);
+
+    /**
+     * Runs one tick.
+     *
+     * @param dirtyIslandIds  dirty island ids for this epoch (may be {@code null}).
+     * @param currentEpoch    monotonic epoch counter.
+     * @param outFailures     caller-sized int[]; on return, {@code out[0]} holds
+     *                        the failure count, followed by {@code count} tuples
+     *                        of 4 ints: {@code x, y, z, failureType}. May be
+     *                        {@code null} if the caller does not need failure data.
+     * @return {@link PFSFResult} code.
+     */
+    public static native int nativeTick(long handle,
+                                         int[] dirtyIslandIds,
+                                         long currentEpoch,
+                                         int[] outFailures);
+
+    /**
+     * Reads the stress utilisation ratio for an island.
+     *
+     * @return number of floats written on success, or a negative
+     *         {@link PFSFResult} code on failure.
+     */
+    public static native int nativeReadStress(long handle, int islandId, float[] outStress);
+
+    /** libpfsf version string. */
+    private static native String nativeVersion();
+
+    /** Mirrors the {@code pfsf_result} enum. */
+    public static final class PFSFResult {
+        public static final int OK                 =  0;
+        public static final int ERROR_VULKAN       = -1;
+        public static final int ERROR_NO_DEVICE    = -2;
+        public static final int ERROR_OUT_OF_VRAM  = -3;
+        public static final int ERROR_INVALID_ARG  = -4;
+        public static final int ERROR_NOT_INIT     = -5;
+        public static final int ERROR_ISLAND_FULL  = -6;
+
+        private PFSFResult() {}
+
+        public static String describe(int code) {
+            return switch (code) {
+                case OK                -> "OK";
+                case ERROR_VULKAN      -> "VULKAN";
+                case ERROR_NO_DEVICE   -> "NO_DEVICE";
+                case ERROR_OUT_OF_VRAM -> "OUT_OF_VRAM";
+                case ERROR_INVALID_ARG -> "INVALID_ARG";
+                case ERROR_NOT_INIT    -> "NOT_INIT";
+                case ERROR_ISLAND_FULL -> "ISLAND_FULL";
+                default                -> "UNKNOWN(" + code + ")";
+            };
+        }
+    }
+}

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/NativePFSFRuntime.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/NativePFSFRuntime.java
@@ -1,0 +1,156 @@
+package com.blockreality.api.physics.pfsf;
+
+import com.blockreality.api.config.BRConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * High-level façade over {@link NativePFSFBridge}.
+ *
+ * <p>Owns a single {@code pfsf_engine} handle for the lifetime of the
+ * server/integrated client, translates between Java-friendly arguments and
+ * the JNI calling convention, and gates activation behind the
+ * {@code -Dblockreality.native.pfsf} system property (v0.3c Phase 1
+ * safety posture — default OFF).</p>
+ *
+ * <p>This class is intentionally lifecycle-only for Phase 1. Tick routing
+ * into the native solver will be wired up in Phase 1b together with the
+ * JNI callback trampolines; for now, {@link #isActive()} is authoritative
+ * and every Java call-site that respects it must fall back to the existing
+ * Java path when it returns {@code false}.</p>
+ */
+public final class NativePFSFRuntime {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("PFSF-NativeRT");
+
+    /** Activation flag. Read once; changes require restart. */
+    public static final String ACTIVATION_PROPERTY = "blockreality.native.pfsf";
+
+    private static final boolean FLAG_ENABLED = Boolean.getBoolean(ACTIVATION_PROPERTY);
+
+    private static final AtomicBoolean INIT_ATTEMPTED = new AtomicBoolean(false);
+
+    private static volatile long handle = 0L;
+    private static volatile boolean active = false;
+
+    private NativePFSFRuntime() {}
+
+    // ═══════════════════════════════════════════════════════════════
+    //  Activation gate
+    // ═══════════════════════════════════════════════════════════════
+
+    /**
+     * @return whether callers should delegate to the native runtime this session.
+     *         Equivalent to {@code flagEnabled && libraryLoaded && initSucceeded}.
+     */
+    public static boolean isActive() {
+        return active;
+    }
+
+    /** Diagnostic breakdown — whether the {@code -D} flag was set. */
+    public static boolean isFlagEnabled() {
+        return FLAG_ENABLED;
+    }
+
+    /** Diagnostic breakdown — whether the shared library is on the host. */
+    public static boolean isLibraryLoaded() {
+        return NativePFSFBridge.isAvailable();
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    //  Lifecycle
+    // ═══════════════════════════════════════════════════════════════
+
+    /**
+     * Initialises the native engine iff the activation flag is set and the
+     * library loaded. Idempotent; safe to call multiple times. Failures
+     * flip the runtime into the "inactive" state so callers fall back to
+     * the Java path silently.
+     */
+    public static synchronized void init() {
+        if (!INIT_ATTEMPTED.compareAndSet(false, true)) return;
+
+        if (!FLAG_ENABLED) {
+            LOGGER.debug("Native PFSF runtime disabled: -D{} is not set.", ACTIVATION_PROPERTY);
+            return;
+        }
+        if (!NativePFSFBridge.isAvailable()) {
+            LOGGER.warn("Native PFSF runtime requested (-D{}=true) but libblockreality_pfsf "
+                    + "was not loaded. Falling back to Java solver.", ACTIVATION_PROPERTY);
+            return;
+        }
+
+        long h = 0L;
+        try {
+            h = NativePFSFBridge.nativeCreate(
+                    /* maxIslandSize    */ 50_000,
+                    /* tickBudgetMs     */ Math.max(1, BRConfig.getPFSFTickBudgetMs()),
+                    /* vramBudgetBytes  */ 512L * 1024 * 1024,
+                    /* enablePhaseField */ true,
+                    /* enableMultigrid  */ true);
+            if (h == 0L) {
+                LOGGER.warn("pfsf_create() returned null. Falling back to Java solver.");
+                return;
+            }
+
+            int rc = NativePFSFBridge.nativeInit(h);
+            if (rc != NativePFSFBridge.PFSFResult.OK) {
+                LOGGER.warn("pfsf_init() failed: {}. Falling back to Java solver.",
+                        NativePFSFBridge.PFSFResult.describe(rc));
+                NativePFSFBridge.nativeDestroy(h);
+                return;
+            }
+
+            handle = h;
+            active = true;
+            LOGGER.info("Native PFSF runtime active — libblockreality_pfsf v{} (handle=0x{})",
+                    NativePFSFBridge.getVersion(), Long.toHexString(h));
+        } catch (Throwable t) {
+            LOGGER.error("Native PFSF init threw: {}. Falling back to Java solver.", t.toString(), t);
+            if (h != 0L) {
+                try { NativePFSFBridge.nativeDestroy(h); } catch (Throwable ignored) {}
+            }
+            active = false;
+            handle = 0L;
+        }
+    }
+
+    /** Releases the engine handle. Safe to call multiple times. */
+    public static synchronized void shutdown() {
+        long h = handle;
+        if (h == 0L) return;
+        handle = 0L;
+        active = false;
+        try {
+            NativePFSFBridge.nativeDestroy(h);
+            LOGGER.info("Native PFSF runtime shut down.");
+        } catch (Throwable t) {
+            LOGGER.warn("nativeDestroy threw during shutdown: {}", t.toString());
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    //  Diagnostics
+    // ═══════════════════════════════════════════════════════════════
+
+    /**
+     * @return a human-readable status line for {@code /br vulkan_test} and
+     *         crash reports; never throws.
+     */
+    public static String getStatus() {
+        if (active) {
+            return String.format("Native PFSF: ACTIVE | lib=%s | handle=0x%x",
+                    NativePFSFBridge.getVersion(), handle);
+        }
+        if (!FLAG_ENABLED) return "Native PFSF: DISABLED (flag off)";
+        if (!NativePFSFBridge.isAvailable()) return "Native PFSF: LIBRARY MISSING";
+        return "Native PFSF: INIT FAILED";
+    }
+
+    /** @return engine handle (opaque) — {@code 0} when inactive. */
+    public static long getHandle() {
+        return handle;
+    }
+}

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFEngine.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFEngine.java
@@ -46,6 +46,12 @@ public final class PFSFEngine {
     // ═══ Lifecycle ═══
 
     public static void init() {
+        // v0.3c Phase 1: try the native runtime first. Safe no-op unless the
+        // -Dblockreality.native.pfsf=true flag is set AND libblockreality_pfsf
+        // loaded. Java solver still initialises as the authoritative path for
+        // Phase 1 — native is attached alongside it for diagnostic parity.
+        NativePFSFRuntime.init();
+
         // ★ EIIE-fix: 在 init() 中建立所有實例，保證執行順序可控
         router        = new HybridPhysicsRouter();
         modelRegistry = new BIFROSTModelRegistry();
@@ -70,6 +76,8 @@ public final class PFSFEngine {
             instance.shutdown();
             instance = null;
         }
+        // Mirror init() order — release the native handle last.
+        NativePFSFRuntime.shutdown();
     }
 
     public static boolean isAvailable() {
@@ -80,7 +88,8 @@ public final class PFSFEngine {
         if (instance == null) return "BIFROST: DISABLED";
         return instance.getStats() + " | " + router.getStats()
                 + " | " + modelRegistry.getStats() + " | " + chunkLOD.getStats()
-                + " | " + cognitiveLOD.getStats();
+                + " | " + cognitiveLOD.getStats()
+                + " | " + NativePFSFRuntime.getStatus();
     }
 
     // ═══ Tick ═══

--- a/L1-native/libpfsf/CMakeLists.txt
+++ b/L1-native/libpfsf/CMakeLists.txt
@@ -64,11 +64,33 @@ if(WIN32)
     target_compile_definitions(pfsf PRIVATE PFSF_EXPORT)
 endif()
 
-# ── JNI bridge (Phase 2) ──
+# ── JNI bridge (v0.3c Phase 1) ──
+# Builds libblockreality_pfsf — the shared library loaded by
+# com.blockreality.api.physics.pfsf.NativePFSFBridge via System.loadLibrary.
+# Produces:
+#   Linux   → libblockreality_pfsf.so
+#   macOS   → libblockreality_pfsf.dylib
+#   Windows → blockreality_pfsf.dll
 if(PFSF_BUILD_JNI AND JNI_FOUND)
-    message(STATUS "[libpfsf] JNI found — building JNI bridge")
-    # Phase 2: add_library(pfsf_jni SHARED src/jni/native_pfsf_runtime.cpp)
-    # target_link_libraries(pfsf_jni PRIVATE pfsf JNI::JNI)
+    message(STATUS "[libpfsf] JNI found — building JNI bridge (blockreality_pfsf)")
+    add_library(blockreality_pfsf SHARED src/jni/native_pfsf_bridge.cpp)
+    target_link_libraries(blockreality_pfsf PRIVATE pfsf JNI::JNI)
+    target_include_directories(blockreality_pfsf PRIVATE ${JNI_INCLUDE_DIRS})
+
+    # Strip the default "lib" prefix so the output name matches System.loadLibrary("blockreality_pfsf").
+    # On Linux/macOS the shared library stem must be exactly "blockreality_pfsf" for that call to resolve.
+    if(NOT WIN32)
+        set_target_properties(blockreality_pfsf PROPERTIES PREFIX "lib")
+    endif()
+
+    # Hide non-exported C++ symbols so the JNI ABI surface stays minimal.
+    set_target_properties(blockreality_pfsf PROPERTIES
+        CXX_VISIBILITY_PRESET hidden
+        VISIBILITY_INLINES_HIDDEN ON)
+
+    install(TARGETS blockreality_pfsf
+        LIBRARY DESTINATION lib
+        RUNTIME DESTINATION bin)
 endif()
 
 # ── Standalone CLI example ──

--- a/L1-native/libpfsf/src/jni/native_pfsf_bridge.cpp
+++ b/L1-native/libpfsf/src/jni/native_pfsf_bridge.cpp
@@ -1,0 +1,345 @@
+/**
+ * @file native_pfsf_bridge.cpp
+ * @brief JNI bridge — exposes libpfsf C API to the Java side.
+ *
+ * Counterpart: com.blockreality.api.physics.pfsf.NativePFSFBridge
+ *
+ * Design notes (v0.3c Phase 1):
+ *   - Opaque jlong handles carry pfsf_engine across the JNI boundary —
+ *     zero JVM object allocation per call.
+ *   - Lifecycle + island + tick + stats are exposed. The Java-side callbacks
+ *     (material/anchor/fill_ratio/curing lookup) are staged for Phase 1b;
+ *     Phase 1 ships the scaffolding and a lookup-less tick so the Java
+ *     side can validate end-to-end wiring via isAvailable()/version().
+ *   - All methods catch native exceptions so JNI never escapes with a
+ *     C++ exception (which is UB across the ABI boundary).
+ */
+
+#include <jni.h>
+#include <pfsf/pfsf.h>
+
+#include <cstring>
+#include <cstdlib>
+#include <new>
+
+namespace {
+
+inline pfsf_engine as_engine(jlong h) {
+    return reinterpret_cast<pfsf_engine>(static_cast<uintptr_t>(h));
+}
+
+inline jlong as_handle(pfsf_engine e) {
+    return static_cast<jlong>(reinterpret_cast<uintptr_t>(e));
+}
+
+} // namespace
+
+extern "C" {
+
+/* ═══════════════════════════════════════════════════════════════
+ *  Lifecycle
+ * ═══════════════════════════════════════════════════════════════ */
+
+JNIEXPORT jlong JNICALL
+Java_com_blockreality_api_physics_pfsf_NativePFSFBridge_nativeCreate(
+        JNIEnv* env, jclass,
+        jint    maxIslandSize,
+        jint    tickBudgetMs,
+        jlong   vramBudgetBytes,
+        jboolean enablePhaseField,
+        jboolean enableMultigrid) {
+    (void) env;
+
+    pfsf_config cfg{};
+    cfg.max_island_size    = (maxIslandSize > 0) ? maxIslandSize : 50000;
+    cfg.tick_budget_ms     = (tickBudgetMs > 0) ? tickBudgetMs : 8;
+    cfg.vram_budget_bytes  = (vramBudgetBytes > 0) ? vramBudgetBytes
+                                                    : (512LL * 1024 * 1024);
+    cfg.enable_phase_field = (enablePhaseField == JNI_TRUE);
+    cfg.enable_multigrid   = (enableMultigrid  == JNI_TRUE);
+
+    pfsf_engine e = pfsf_create(&cfg);
+    return as_handle(e);
+}
+
+JNIEXPORT jint JNICALL
+Java_com_blockreality_api_physics_pfsf_NativePFSFBridge_nativeInit(
+        JNIEnv*, jclass, jlong handle) {
+    if (handle == 0) return PFSF_ERROR_INVALID_ARG;
+    return static_cast<jint>(pfsf_init(as_engine(handle)));
+}
+
+JNIEXPORT void JNICALL
+Java_com_blockreality_api_physics_pfsf_NativePFSFBridge_nativeShutdown(
+        JNIEnv*, jclass, jlong handle) {
+    if (handle == 0) return;
+    pfsf_shutdown(as_engine(handle));
+}
+
+JNIEXPORT void JNICALL
+Java_com_blockreality_api_physics_pfsf_NativePFSFBridge_nativeDestroy(
+        JNIEnv*, jclass, jlong handle) {
+    if (handle == 0) return;
+    pfsf_destroy(as_engine(handle));
+}
+
+JNIEXPORT jboolean JNICALL
+Java_com_blockreality_api_physics_pfsf_NativePFSFBridge_nativeIsAvailable(
+        JNIEnv*, jclass, jlong handle) {
+    if (handle == 0) return JNI_FALSE;
+    return pfsf_is_available(as_engine(handle)) ? JNI_TRUE : JNI_FALSE;
+}
+
+/* ═══════════════════════════════════════════════════════════════
+ *  Stats (thread-safe per C API contract)
+ *
+ *  Returns a 5-element long[] encoding:
+ *    [0] island_count           (int32 widened)
+ *    [1] total_voxels
+ *    [2] vram_used_bytes
+ *    [3] vram_budget_bytes
+ *    [4] last_tick_ms * 1000    (float→int µs, avoids jfloat[] alloc)
+ * ═══════════════════════════════════════════════════════════════ */
+
+JNIEXPORT jlongArray JNICALL
+Java_com_blockreality_api_physics_pfsf_NativePFSFBridge_nativeGetStats(
+        JNIEnv* env, jclass, jlong handle) {
+    if (handle == 0) return nullptr;
+
+    pfsf_stats stats{};
+    if (pfsf_get_stats(as_engine(handle), &stats) != PFSF_OK) {
+        return nullptr;
+    }
+
+    jlongArray out = env->NewLongArray(5);
+    if (out == nullptr) return nullptr;
+
+    jlong vals[5] = {
+        static_cast<jlong>(stats.island_count),
+        static_cast<jlong>(stats.total_voxels),
+        static_cast<jlong>(stats.vram_used_bytes),
+        static_cast<jlong>(stats.vram_budget_bytes),
+        static_cast<jlong>(stats.last_tick_ms * 1000.0f),
+    };
+    env->SetLongArrayRegion(out, 0, 5, vals);
+    return out;
+}
+
+/* ═══════════════════════════════════════════════════════════════
+ *  Wind
+ * ═══════════════════════════════════════════════════════════════ */
+
+JNIEXPORT void JNICALL
+Java_com_blockreality_api_physics_pfsf_NativePFSFBridge_nativeSetWind(
+        JNIEnv*, jclass, jlong handle,
+        jfloat wx, jfloat wy, jfloat wz) {
+    if (handle == 0) return;
+    pfsf_vec3 w{ wx, wy, wz };
+    pfsf_set_wind(as_engine(handle), &w);
+}
+
+/* ═══════════════════════════════════════════════════════════════
+ *  Island management
+ * ═══════════════════════════════════════════════════════════════ */
+
+JNIEXPORT jint JNICALL
+Java_com_blockreality_api_physics_pfsf_NativePFSFBridge_nativeAddIsland(
+        JNIEnv*, jclass, jlong handle,
+        jint islandId,
+        jint ox, jint oy, jint oz,
+        jint lx, jint ly, jint lz) {
+    if (handle == 0) return PFSF_ERROR_INVALID_ARG;
+
+    pfsf_island_desc desc{};
+    desc.island_id = islandId;
+    desc.origin.x  = ox;
+    desc.origin.y  = oy;
+    desc.origin.z  = oz;
+    desc.lx = lx;
+    desc.ly = ly;
+    desc.lz = lz;
+    return static_cast<jint>(pfsf_add_island(as_engine(handle), &desc));
+}
+
+JNIEXPORT void JNICALL
+Java_com_blockreality_api_physics_pfsf_NativePFSFBridge_nativeRemoveIsland(
+        JNIEnv*, jclass, jlong handle, jint islandId) {
+    if (handle == 0) return;
+    pfsf_remove_island(as_engine(handle), islandId);
+}
+
+JNIEXPORT void JNICALL
+Java_com_blockreality_api_physics_pfsf_NativePFSFBridge_nativeMarkFullRebuild(
+        JNIEnv*, jclass, jlong handle, jint islandId) {
+    if (handle == 0) return;
+    pfsf_mark_full_rebuild(as_engine(handle), islandId);
+}
+
+/* ═══════════════════════════════════════════════════════════════
+ *  Sparse voxel update
+ *
+ *  The 6-way conductivity array is passed as a packed float[6] region
+ *  to avoid building a pfsf_voxel_update via many JNI calls.
+ * ═══════════════════════════════════════════════════════════════ */
+
+JNIEXPORT jint JNICALL
+Java_com_blockreality_api_physics_pfsf_NativePFSFBridge_nativeNotifyBlockChange(
+        JNIEnv* env, jclass,
+        jlong handle,
+        jint islandId,
+        jint flatIndex,
+        jfloat source,
+        jint voxelType,
+        jfloat maxPhi,
+        jfloat rcomp,
+        jfloatArray cond6) {
+    if (handle == 0) return PFSF_ERROR_INVALID_ARG;
+    if (cond6 == nullptr || env->GetArrayLength(cond6) < 6) return PFSF_ERROR_INVALID_ARG;
+
+    pfsf_voxel_update u{};
+    u.flat_index = flatIndex;
+    u.source     = source;
+    u.type       = static_cast<pfsf_voxel_type>(voxelType);
+    u.max_phi    = maxPhi;
+    u.rcomp      = rcomp;
+
+    jfloat* src = env->GetFloatArrayElements(cond6, nullptr);
+    if (src == nullptr) return PFSF_ERROR_INVALID_ARG;
+    for (int i = 0; i < 6; ++i) u.cond[i] = src[i];
+    env->ReleaseFloatArrayElements(cond6, src, JNI_ABORT);
+
+    return static_cast<jint>(pfsf_notify_block_change(as_engine(handle), islandId, &u));
+}
+
+/* ═══════════════════════════════════════════════════════════════
+ *  Tick
+ *
+ *  dirtyIslandIds may be null (no dirty islands — still advance epoch).
+ *  outFailures is a caller-sized int[] encoding failure events as
+ *  tuples of (x, y, z, type) — capacity must be a multiple of 4.
+ *  Returns the result code; the number of failures written is encoded
+ *  in the high 16 bits of the returned jint shifted left by 16 when
+ *  PFSF_OK (result codes are small negatives so this is unambiguous).
+ *  For a cleaner API the Java side reads the count via the array's
+ *  [0] element after the call — see NativePFSFBridge.tick() docs.
+ *
+ *  Convention: outFailures[0] = count written; outFailures[1..] = events.
+ *  Each event is 4 ints: x, y, z, type.
+ * ═══════════════════════════════════════════════════════════════ */
+
+JNIEXPORT jint JNICALL
+Java_com_blockreality_api_physics_pfsf_NativePFSFBridge_nativeTick(
+        JNIEnv* env, jclass,
+        jlong handle,
+        jintArray dirtyIslandIds,
+        jlong currentEpoch,
+        jintArray outFailures) {
+    if (handle == 0) return PFSF_ERROR_INVALID_ARG;
+
+    jint*  dirtyBuf = nullptr;
+    jsize  dirtyLen = 0;
+    if (dirtyIslandIds != nullptr) {
+        dirtyLen = env->GetArrayLength(dirtyIslandIds);
+        if (dirtyLen > 0) {
+            dirtyBuf = env->GetIntArrayElements(dirtyIslandIds, nullptr);
+            if (dirtyBuf == nullptr) return PFSF_ERROR_INVALID_ARG;
+        }
+    }
+
+    /* Build the failure-event scratch area. */
+    pfsf_tick_result tickResult{};
+    tickResult.events   = nullptr;
+    tickResult.capacity = 0;
+    tickResult.count    = 0;
+
+    pfsf_failure_event* eventBuf = nullptr;
+    jint outCapacity = 0;
+    if (outFailures != nullptr) {
+        outCapacity = env->GetArrayLength(outFailures);
+        /* Reserve index 0 for the count. Each event costs 4 ints. */
+        jint usable = (outCapacity > 1) ? (outCapacity - 1) / 4 : 0;
+        if (usable > 0) {
+            eventBuf = static_cast<pfsf_failure_event*>(
+                std::calloc(static_cast<size_t>(usable), sizeof(pfsf_failure_event)));
+            if (eventBuf != nullptr) {
+                tickResult.events   = eventBuf;
+                tickResult.capacity = usable;
+            }
+        }
+    }
+
+    pfsf_result r = pfsf_tick(
+        as_engine(handle),
+        reinterpret_cast<const int32_t*>(dirtyBuf),
+        static_cast<int32_t>(dirtyLen),
+        static_cast<int64_t>(currentEpoch),
+        (tickResult.events != nullptr) ? &tickResult : nullptr);
+
+    if (dirtyBuf != nullptr) {
+        env->ReleaseIntArrayElements(dirtyIslandIds, dirtyBuf, JNI_ABORT);
+    }
+
+    /* Write the failure count + events back to outFailures. */
+    if (outFailures != nullptr && outCapacity > 0) {
+        jint count = tickResult.count;
+        env->SetIntArrayRegion(outFailures, 0, 1, &count);
+        if (eventBuf != nullptr && count > 0) {
+            /* Serialize as [x,y,z,type] tuples into outFailures[1..]. */
+            jint* packed = static_cast<jint*>(std::malloc(sizeof(jint) * 4 * count));
+            if (packed != nullptr) {
+                for (jint i = 0; i < count; ++i) {
+                    packed[i * 4 + 0] = eventBuf[i].pos.x;
+                    packed[i * 4 + 1] = eventBuf[i].pos.y;
+                    packed[i * 4 + 2] = eventBuf[i].pos.z;
+                    packed[i * 4 + 3] = static_cast<jint>(eventBuf[i].type);
+                }
+                env->SetIntArrayRegion(outFailures, 1, 4 * count, packed);
+                std::free(packed);
+            }
+        }
+    }
+
+    if (eventBuf != nullptr) std::free(eventBuf);
+    return static_cast<jint>(r);
+}
+
+/* ═══════════════════════════════════════════════════════════════
+ *  Stress field readback
+ * ═══════════════════════════════════════════════════════════════ */
+
+JNIEXPORT jint JNICALL
+Java_com_blockreality_api_physics_pfsf_NativePFSFBridge_nativeReadStress(
+        JNIEnv* env, jclass,
+        jlong handle,
+        jint islandId,
+        jfloatArray outStress) {
+    if (handle == 0 || outStress == nullptr) return PFSF_ERROR_INVALID_ARG;
+
+    jsize capacity = env->GetArrayLength(outStress);
+    if (capacity <= 0) return PFSF_ERROR_INVALID_ARG;
+
+    jfloat* buf = env->GetFloatArrayElements(outStress, nullptr);
+    if (buf == nullptr) return PFSF_ERROR_INVALID_ARG;
+
+    int32_t written = 0;
+    pfsf_result r = pfsf_read_stress(
+        as_engine(handle), islandId,
+        buf, static_cast<int32_t>(capacity), &written);
+
+    /* COMMIT writes the buffer back to Java regardless of partial success. */
+    env->ReleaseFloatArrayElements(outStress, buf, 0);
+    return (r == PFSF_OK) ? written : static_cast<jint>(r);
+}
+
+/* ═══════════════════════════════════════════════════════════════
+ *  Version
+ * ═══════════════════════════════════════════════════════════════ */
+
+JNIEXPORT jstring JNICALL
+Java_com_blockreality_api_physics_pfsf_NativePFSFBridge_nativeVersion(
+        JNIEnv* env, jclass) {
+    const char* v = pfsf_version();
+    return (v != nullptr) ? env->NewStringUTF(v) : env->NewStringUTF("unknown");
+}
+
+} /* extern "C" */


### PR DESCRIPTION
啟用既有 L1-native/libpfsf 的 JNI 出口，為後續將 PFSF 物理、Vulkan
RT、流體完全遷移至原生 C++ 打下基礎。本階段僅鋪線，預設關閉，不影響現行 Java 求解器。

- L1-native/libpfsf/src/jni/native_pfsf_bridge.cpp: 新增 JNIEXPORT shim
  包裝 lifecycle / island / sparse update / tick / stress / stats /
  version，全以 jlong opaque handle + 原生陣列傳遞，零 JVM 物件配置
  於熱路徑。
- L1-native/libpfsf/CMakeLists.txt: 啟用 blockreality_pfsf SHARED target，
  hidden visibility + lib 前綴對齊 System.loadLibrary("blockreality_pfsf")。
- NativePFSFBridge.java: 仿 BRNRDNative 載入模式，UnsatisfiedLinkError
  → graceful fallback，導出 PFSFResult 常數。
- NativePFSFRuntime.java: 門面；-Dblockreality.native.pfsf=true 才啟用，
  失敗一律回退 Java 路徑；暴露 getStatus() 供 /br 診斷。
- PFSFEngine.init()/shutdown()/getStats(): 串接 NativePFSFRuntime 生命
  週期，Java solver 仍為 Phase 1 權威路徑，原生路徑僅附掛診斷。
- api/build.gradle: nativeConfigure + nativeBuild Gradle tasks，依
  -Pblockreality.native.build=true 啟動，輸出至 META-INF/native/<triple>/，
  CMake 不存在時靜默跳過，保持既有開發流程不變。

驗證：Java 側以 javac --release 17 單檔編譯通過；C++ 側以 g++ 17 +
OpenJDK 21 headers 通過 syntax-only check。完整 runClient/runServer
驗證依 Phase 1b（callback trampoline + tick 委派）再進行。

https://claude.ai/code/session_019r4oQdcG8yzfdjeohnhr77