### PR TITLE
fix

### DIFF
--- a/Block Reality/api/src/main/java/com/blockreality/api/collapse/CollapseManager.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/collapse/CollapseManager.java
@@ -100,6 +100,9 @@ public class CollapseManager {
      * 應在 ServerTickEvent.Post 中呼叫。
      */
     public static void processQueue() {
+        // Auto-reset suppressCollapse per tick (matches Javadoc contract; caller sets it before tick logic)
+        suppressCollapse.set(false);
+
         // ★ Audit fix: 回填溢出暫存，確保無方塊永久遺失
         if (!overflowBuffer.isEmpty() && collapseQueue.size() < BRConfig.getCollapseQueueMaxSize()) {
             int refilled = 0;
@@ -162,10 +165,15 @@ public class CollapseManager {
         if (!(be instanceof RBlockEntity)) return;
 
         // ─── 記錄到崩塌日誌（undo 回滾用）───
+        // chainId uses server tick so collapses in the same tick form one undo-able chain,
+        // rather than all PFSF collapses ever sharing chainId=-1.
         long tick = level.getServer() != null ? level.getServer().getTickCount() : 0;
-        JOURNAL.record(pos, state, type, tick, -1);
+        JOURNAL.record(pos, state, type, tick, (int)(tick & Integer.MAX_VALUE));
 
-        level.removeBlockEntity(pos);
+        // NOTE: do NOT call level.removeBlockEntity here.
+        // FallingBlockEntity.fall() calls level.setBlock(AIR) which triggers BE cleanup,
+        // and level.destroyBlock() also removes the BE internally.
+        // Premature removal here would prevent FallingBlockEntity from serialising BE NBT.
 
         switch (type) {
             case CANTILEVER_BREAK -> {
@@ -378,10 +386,19 @@ public class CollapseManager {
      */
     public static void triggerPFSFCollapse(ServerLevel level, BlockPos pos,
                                             FailureType type) {
+        // Capture matId BEFORE triggerCollapseAt removes the block entity via destroyBlock /
+        // FallingBlockEntity.fall(); after that call getBlockEntity(pos) returns null.
+        int matId = getMaterialId(level, pos);
+
+        // Fire event so external mods can intercept individual PFSF collapses
+        // (consistent with batch enqueueCollapse which also fires before acting).
+        RStructureCollapseEvent event = new RStructureCollapseEvent(level, pos,
+                java.util.Set.of(pos));
+        MinecraftForge.EVENT_BUS.post(event);
+
         triggerCollapseAt(level, pos, type);
 
         // M10-fix: 廣播崩塌效果到附近客戶端（多人同步）
-        int matId = getMaterialId(level, pos);
         Map<BlockPos, CollapseEffectPacket.CollapseInfo> data = new java.util.HashMap<>();
         data.put(pos, new CollapseEffectPacket.CollapseInfo(type, matId));
         broadcastCollapseEffects(level, pos, data);

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/IslandBufferEvictor.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/IslandBufferEvictor.java
@@ -101,7 +101,7 @@ public final class IslandBufferEvictor {
             if (buf != null) {
                 LOGGER.info("[PFSF] Evicting island {} (idle {} ticks, VRAM pressure={:.1f}%)",
                         islandId, idleTicks, pressure * 100);
-                PFSFBufferManager.removeBuffer(islandId);
+                PFSFEngine.removeBuffer(islandId); // also notifies native engine GPU cleanup
                 evicted++;
             }
 

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/NativePFSFRuntime.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/NativePFSFRuntime.java
@@ -96,8 +96,26 @@ public final class NativePFSFRuntime {
         return "Native PFSF: INACTIVE";
     }
 
+    /**
+     * Notifies the native engine that an island is being removed (eviction, world unload, etc.).
+     * Called from PFSFEngine.removeBuffer so IslandBufferEvictor and AABB-expansion paths
+     * also clean up the native GPU allocation — not just explicit API callers.
+     */
+    static void notifyIslandRemoved(int islandId) {
+        if (active && handle != 0L) {
+            NativePFSFBridge.nativeRemoveIsland(handle, islandId);
+            VIEW.nativeIslandDims.remove(islandId);
+        }
+    }
+
     static final class RuntimeView implements IPFSFRuntime {
         private long lastProcessedEpoch = -1;
+
+        // Tracks (lx, ly, lz) registered per island in the native engine.
+        // nativeAddIsland is called only when an island is new or its AABB changed.
+        // C++ getOrCreate re-allocates GPU buffers when dims differ, so re-adding is safe.
+        final java.util.Map<Integer, int[]> nativeIslandDims =
+                new java.util.concurrent.ConcurrentHashMap<>();
 
         @Override public void init() { NativePFSFRuntime.init(); }
         @Override public void shutdown() { NativePFSFRuntime.shutdown(); }
@@ -114,34 +132,64 @@ public final class NativePFSFRuntime {
                 return;
             }
 
-            int[] dirtyIds = new int[dirtyIslands.size()];
-            int idx = 0;
+            // Two-pass: first prepare all islands, then tick together.
+            // This lets nativeTickDbb batch all dirty islands in one submit.
+            java.util.List<Integer> tickableIds = new java.util.ArrayList<>(dirtyIslands.size());
             for (int id : dirtyIslands.keySet()) {
-                dirtyIds[idx++] = id;
+                StructureIsland island = dirtyIslands.get(id);
                 PFSFIslandBuffer buf = PFSFBufferManager.getBuffer(id);
-                if (buf == null) buf = PFSFBufferManager.getOrCreateBuffer(dirtyIslands.get(id));
-                
-                if (buf != null) {
-                    PFSFDataBuilder.updateSourceAndConductivity(buf, dirtyIslands.get(id), level,
-                            PFSFEngine.getMaterialLookup(), PFSFEngine.getAnchorLookup(),
-                            PFSFEngine.getFillRatioLookup(), PFSFEngine.getCuringLookup(),
-                            PFSFEngine.getCurrentWindVec(), null);
-                    
-                    NativePFSFBridge.nativeRegisterIslandBuffers(handle, id,
-                            buf.getPhiBufAsBB(), buf.getSourceBufAsBB(), buf.getCondBufAsBB(),
-                            buf.getTypeBufAsBB(), buf.getRcompBufAsBB(), buf.getRtensBufAsBB(),
-                            buf.getMaxPhiBufAsBB());
+                if (buf == null) buf = PFSFBufferManager.getOrCreateBuffer(island);
+                if (buf == null) continue;  // VRAM budget rejected
+
+                // Register island with native engine (or re-register on AABB change).
+                int lx = buf.getLx(), ly = buf.getLy(), lz = buf.getLz();
+                int[] registered = nativeIslandDims.get(id);
+                if (registered == null || registered[0] != lx || registered[1] != ly || registered[2] != lz) {
+                    net.minecraft.core.BlockPos origin = buf.getOrigin();
+                    int rc = NativePFSFBridge.nativeAddIsland(handle, id,
+                            origin.getX(), origin.getY(), origin.getZ(), lx, ly, lz);
+                    if (rc != NativePFSFBridge.PFSFResult.OK) {
+                        LOGGER.warn("nativeAddIsland failed for island {} (rc={})", id, rc);
+                        continue;
+                    }
+                    nativeIslandDims.put(id, new int[]{lx, ly, lz});
                 }
+
+                // Compute & normalise source/conductivity into hostCoalescedBuf (zero-copy DBB).
+                PFSFDataBuilder.updateSourceAndConductivity(buf, island, level,
+                        PFSFEngine.getMaterialLookup(), PFSFEngine.getAnchorLookup(),
+                        PFSFEngine.getFillRatioLookup(), PFSFEngine.getCuringLookup(),
+                        PFSFEngine.getCurrentWindVec(), null);
+
+                // Register persistent host-side DBBs so native reads from hostCoalescedBuf.
+                int regRc = NativePFSFBridge.nativeRegisterIslandBuffers(handle, id,
+                        buf.getPhiBufAsBB(), buf.getSourceBufAsBB(), buf.getCondBufAsBB(),
+                        buf.getTypeBufAsBB(), buf.getRcompBufAsBB(), buf.getRtensBufAsBB(),
+                        buf.getMaxPhiBufAsBB());
+                if (regRc != NativePFSFBridge.PFSFResult.OK) {
+                    LOGGER.warn("nativeRegisterIslandBuffers failed for island {} (rc={})", id, regRc);
+                    continue;
+                }
+
+                tickableIds.add(id);
             }
 
-            ByteBuffer failBuf = ByteBuffer.allocateDirect(4 + 1024 * 16).order(java.nio.ByteOrder.LITTLE_ENDIAN);
+            if (tickableIds.isEmpty()) {
+                lastProcessedEpoch = currentEpoch;
+                return;
+            }
+
+            int[] dirtyIds = tickableIds.stream().mapToInt(Integer::intValue).toArray();
+            ByteBuffer failBuf = ByteBuffer.allocateDirect(4 + 1024 * 16)
+                    .order(java.nio.ByteOrder.LITTLE_ENDIAN);
+            failBuf.putInt(0, 0); // C++ reads header count and appends; must start at 0
             int rc = NativePFSFBridge.nativeTickDbb(handle, dirtyIds, currentEpoch, failBuf);
             if (rc == NativePFSFBridge.PFSFResult.OK) {
                 int count = failBuf.getInt(0);
                 for (int i = 0; i < Math.min(count, 1024); i++) {
-                    int x = failBuf.getInt(4 + i * 16);
-                    int y = failBuf.getInt(8 + i * 16);
-                    int z = failBuf.getInt(12 + i * 16);
+                    int x        = failBuf.getInt(4  + i * 16);
+                    int y        = failBuf.getInt(8  + i * 16);
+                    int z        = failBuf.getInt(12 + i * 16);
                     int nativeType = failBuf.getInt(16 + i * 16);
                     BlockPos pos = new BlockPos(x, y, z);
                     com.blockreality.api.physics.FailureType type = switch (nativeType) {
@@ -175,7 +223,9 @@ public final class NativePFSFRuntime {
 
         @Override
         public void removeBuffer(int islandId) {
-            if (active) NativePFSFBridge.nativeRemoveIsland(handle, islandId);
+            // Native engine GPU cleanup is handled by notifyIslandRemoved (called from PFSFEngine).
+            // This override exists for IPFSFRuntime contract completeness.
+            notifyIslandRemoved(islandId);
         }
     }
 }

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/NativePFSFRuntime.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/NativePFSFRuntime.java
@@ -162,14 +162,28 @@ public final class NativePFSFRuntime {
                         PFSFEngine.getCurrentWindVec(), null);
 
                 // Register persistent host-side DBBs so native reads from hostCoalescedBuf.
+                java.nio.ByteBuffer phiBB = buf.getPhiBufAsBB();
                 int regRc = NativePFSFBridge.nativeRegisterIslandBuffers(handle, id,
-                        buf.getPhiBufAsBB(), buf.getSourceBufAsBB(), buf.getCondBufAsBB(),
+                        phiBB, buf.getSourceBufAsBB(), buf.getCondBufAsBB(),
                         buf.getTypeBufAsBB(), buf.getRcompBufAsBB(), buf.getRtensBufAsBB(),
                         buf.getMaxPhiBufAsBB());
                 if (regRc != NativePFSFBridge.PFSFResult.OK) {
                     LOGGER.warn("nativeRegisterIslandBuffers failed for island {} (rc={})", id, regRc);
                     continue;
                 }
+
+                // Phi warm-start: after each dispatch C++ writes GPU phi back into phiBB
+                // (hostCoalescedBuf[phiOffset..]). The next tick's uploadFromHosts reads
+                // this warm solution, avoiding cold-start convergence from phi=0 each tick.
+                // phiBB is a duplicate slice of hostCoalescedBuf — same backing memory.
+                NativePFSFBridge.nativeRegisterStressReadback(handle, id, phiBB);
+
+                // Augmentation lookups — curing is wired; materialId/anchorBitmap/fluidPressure
+                // are zero-filled stubs (not used in uploadFromHosts but required non-null by ABI).
+                // PFSFDataBuilder.writeLookupCuring() was already called inside updateSourceAndConductivity.
+                NativePFSFBridge.nativeRegisterIslandLookups(handle, id,
+                        buf.getLookupMaterialIdBB(), buf.getLookupAnchorBitmapBB(),
+                        buf.getLookupFluidPressureBB(), buf.getLookupCuringBB());
 
                 tickableIds.add(id);
             }

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFDataBuilder.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFDataBuilder.java
@@ -175,6 +175,10 @@ public final class PFSFDataBuilder {
         // 我們限制正規化因子的最大值。這可能會降低數值穩定性，但能保證重力項不消失。
         normalizeSoA6(source, rcomp, rtens, conductivity, null, maxPhi, N);
 
+        // Populate the host-side DBB mirror for the native zero-copy tick path.
+        // Must happen before uploadSourceAndConductivity so native sees the
+        // normalized arrays (same values the GPU will receive via staging copy).
+        buf.writeToPersistentHostBuf(source, conductivity, type, maxPhi, rcomp, rtens);
         buf.uploadSourceAndConductivity(source, conductivity, type, maxPhi, rcomp, rtens);
 
         // 粗網格資料（L0 → L1 → L2）

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFDataBuilder.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFDataBuilder.java
@@ -155,7 +155,12 @@ public final class PFSFDataBuilder {
         }
 
         // 上傳水化度陣列到 GPU（v2.1 phase_field_evolve.comp 將讀取此陣列計算 G_c(t)）
-        buf.uploadHydration(hydration);
+        if (!NativePFSFRuntime.isActive()) {
+            buf.uploadHydration(hydration);  // Java GPU path: upload to phaseField.hydrationBuf
+        }
+        // Native path: write hydration into lookupCuring DBB; C++ uploadFromHosts copies it
+        // to hydration_buf so phase_field_evolve sees the actual curing state, not the 1.0f seed.
+        buf.writeLookupCuring(hydration);
 
         // Diagonal phantom edges
         int phantomCount = PFSFSourceBuilder.injectDiagonalPhantomEdges(
@@ -175,15 +180,20 @@ public final class PFSFDataBuilder {
         // 我們限制正規化因子的最大值。這可能會降低數值穩定性，但能保證重力項不消失。
         normalizeSoA6(source, rcomp, rtens, conductivity, null, maxPhi, N);
 
-        // Populate the host-side DBB mirror for the native zero-copy tick path.
-        // Must happen before uploadSourceAndConductivity so native sees the
-        // normalized arrays (same values the GPU will receive via staging copy).
+        // Populate host-side DBB mirror for the native zero-copy tick path first.
         buf.writeToPersistentHostBuf(source, conductivity, type, maxPhi, rcomp, rtens);
-        buf.uploadSourceAndConductivity(source, conductivity, type, maxPhi, rcomp, rtens);
 
-        // 粗網格資料（L0 → L1 → L2）
+        // When native engine is active it owns all GPU uploads via uploadFromHosts()
+        // inside pfsf_tick_dbb. Skip the Java-side staging → coalescedBuf copy and
+        // the multigrid coarse-grid uploads to avoid redundant GPU bandwidth.
+        final boolean nativeActive = NativePFSFRuntime.isActive();
+        if (!nativeActive) {
+            buf.uploadSourceAndConductivity(source, conductivity, type, maxPhi, rcomp, rtens);
+        }
+
+        // 粗網格資料（L0 → L1 → L2） — Java path only; native dispatcher builds its own.
         buf.allocateMultigrid();
-        if (buf.getN_L1() > 0) {
+        if (!nativeActive && buf.getN_L1() > 0) {
             float[] l1Cond = new float[buf.getN_L1() * 6];
             byte[] l1Type = new byte[buf.getN_L1()];
             downsample(conductivity, type,

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFEngine.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFEngine.java
@@ -177,6 +177,8 @@ public final class PFSFEngine {
     // ═══ Buffer Access ═══
 
     public static void removeBuffer(int islandId) {
+        // Notify native engine so its GPU allocation is freed (eviction, world unload, AABB change).
+        NativePFSFRuntime.notifyIslandRemoved(islandId);
         if (instance != null) instance.removeBuffer(islandId);
     }
 

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFEngineInstance.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFEngineInstance.java
@@ -64,13 +64,15 @@ public final class PFSFEngineInstance implements IPFSFRuntime {
         }
         try {
             PFSFPipelineFactory.createAll();
-            long pool = VulkanComputeContext.createIsolatedDescriptorPool(2048, 8192, "PFSF");
+            // 4096 sets / 16384 bindings: each island ~15 DS/tick (RBGS×8+PCG×4+failure×3);
+            // supports ~270 islands per 40-tick pool window before exhaustion.
+            long pool = VulkanComputeContext.createIsolatedDescriptorPool(4096, 16384, "PFSF");
             if (pool == 0) {
                 LOGGER.error("[PFSF] createIsolatedDescriptorPool returned 0 handle — init aborted");
                 available = false;
                 return;
             }
-            descriptorPoolMgr = new DescriptorPoolManager(pool, 2048, "PFSF");
+            descriptorPoolMgr = new DescriptorPoolManager(pool, 4096, "PFSF");
             available = true;
             // PR#187 capy-ai R15: register the canonical augmentation binders
             // in production. Without this, PFSFAugmentationHost.BINDERS stays

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFFailureRecorder.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFFailureRecorder.java
@@ -111,7 +111,8 @@ public final class PFSFFailureRecorder {
 
             long ds = VulkanComputeContext.allocateDescriptorSet(descriptorPool, compactDSLayout);
             if (ds == 0) {
-                LOGGER.error("[PFSF] Descriptor set allocation failed (pool exhausted) in recordFailureCompact");
+                LOGGER.warn("[PFSF] Descriptor pool exhausted in recordFailureCompact (island {}) — frame skipped, island will be re-queued", buf.getIslandId());
+                VulkanComputeContext.freeBuffer(compactBuf[0], compactBuf[1]); // fix VRAM leak
                 return;
             }
             VulkanComputeContext.bindBufferToDescriptor(ds, 0, buf.getFailFlagsBuf(), buf.getFailFlagsOffset(), buf.getTypeSize());
@@ -165,7 +166,8 @@ public final class PFSFFailureRecorder {
             long ds1 = VulkanComputeContext.allocateDescriptorSet(
                     PFSFEngine.getDescriptorPool(), reduceMaxDSLayout);
             if (ds1 == 0) {
-                LOGGER.error("[PFSF] Descriptor set allocation failed (pool exhausted) in recordPhiMaxReduction/pass1");
+                LOGGER.warn("[PFSF] Descriptor pool exhausted in recordPhiMaxReduction/pass1 (island {})", buf.getIslandId());
+                VulkanComputeContext.freeBuffer(partialBuf[0], partialBuf[1]); // fix VRAM leak
                 return;
             }
             VulkanComputeContext.bindBufferToDescriptor(ds1, 0, buf.getPhiBuf(), buf.getPhiOffset(), buf.getPhiSize());
@@ -191,7 +193,9 @@ public final class PFSFFailureRecorder {
             long ds2 = VulkanComputeContext.allocateDescriptorSet(
                     PFSFEngine.getDescriptorPool(), reduceMaxDSLayout);
             if (ds2 == 0) {
-                LOGGER.error("[PFSF] Descriptor set allocation failed (pool exhausted) in recordPhiMaxReduction/pass2");
+                LOGGER.warn("[PFSF] Descriptor pool exhausted in recordPhiMaxReduction/pass2 (island {})", buf.getIslandId());
+                VulkanComputeContext.freeBuffer(partialBuf[0], partialBuf[1]); // fix VRAM leak
+                VulkanComputeContext.freeBuffer(finalBuf[0], finalBuf[1]);     // fix VRAM leak
                 return;
             }
             VulkanComputeContext.bindBufferToDescriptor(ds2, 0, partialBuf[0], 0, partialSize);

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFIslandBuffer.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFIslandBuffer.java
@@ -65,6 +65,17 @@ public class PFSFIslandBuffer {
     // receives correct host addresses (stagingBuf is transient/wrong-sized).
     private ByteBuffer hostCoalescedBuf = null;
 
+    // ─── Lookup DBBs for nativeRegisterIslandLookups ───
+    // Separate direct buffers (not part of coalescedBuf layout) for world-state
+    // lookups. materialIdLookup / anchorBitmapLookup / fluidPressureLookup are
+    // zero-filled stubs (not currently used by uploadFromHosts). curingLookup
+    // IS uploaded to hydration_buf, enabling phase-field damage evolution with
+    // proper hydration when ICuringManager is active.
+    private ByteBuffer lookupMaterialId     = null;  // int32   × N (stub, zeros)
+    private ByteBuffer lookupAnchorBitmap   = null;  // int64   × N (stub, zeros)
+    private ByteBuffer lookupFluidPressure  = null;  // float32 × N (stub, zeros)
+    private ByteBuffer lookupCuring         = null;  // float32 × N (from ICuringManager)
+
     private final PFSFPhaseFieldBuffers phaseField = new PFSFPhaseFieldBuffers();
     private final PFSFMultigridBuffers multigrid = new PFSFMultigridBuffers();
     private PFSFConvergenceState convergence;
@@ -161,6 +172,16 @@ public class PFSFIslandBuffer {
                     .order(java.nio.ByteOrder.LITTLE_ENDIAN);
         }
 
+        // Lookup DBBs for nativeRegisterIslandLookups (zero-initialized stubs + curing).
+        // anchor_bitmap is int64 × N = 8 bytes/voxel; others are int32/float32 × N = 4 bytes/voxel.
+        lookupMaterialId    = ByteBuffer.allocateDirect(N * 4).order(java.nio.ByteOrder.LITTLE_ENDIAN);
+        lookupAnchorBitmap  = ByteBuffer.allocateDirect(N * 8).order(java.nio.ByteOrder.LITTLE_ENDIAN);
+        lookupFluidPressure = ByteBuffer.allocateDirect(N * 4).order(java.nio.ByteOrder.LITTLE_ENDIAN);
+        lookupCuring        = ByteBuffer.allocateDirect(N * 4).order(java.nio.ByteOrder.LITTLE_ENDIAN);
+        // Fill curing with 1.0f (fully cured) so native phase-field matches the C++ default.
+        java.nio.FloatBuffer curingFB = lookupCuring.asFloatBuffer();
+        for (int i = 0; i < N; i++) curingFB.put(i, 1.0f);
+
         coalescedBuf = VulkanComputeContext.allocateDeviceBuffer(coalescedSize, storageUsage);
         if (coalescedBuf == null) {
             LOGGER.error("[PFSF] Island {} coalesced buffer allocation failed", islandId);
@@ -209,7 +230,11 @@ public class PFSFIslandBuffer {
     private void freeGpuResources() {
         freeBufferPair(coalescedBuf); coalescedBuf = null;
         freeBufferPair(stagingBuf); stagingBuf = null;
-        hostCoalescedBuf = null;  // allow GC of off-heap direct buffer
+        hostCoalescedBuf = null;
+        lookupMaterialId = null;
+        lookupAnchorBitmap = null;
+        lookupFluidPressure = null;
+        lookupCuring = null;
         freePCG();
         phaseField.free();
         multigrid.free();
@@ -520,6 +545,20 @@ public class PFSFIslandBuffer {
         dup.position((int) offset).limit((int) (offset + data.length));
         dup.slice().put(data);
     }
+
+    /** Write hydration/curing degree (0..1 float) into the lookup DBB for native phase-field. */
+    public void writeLookupCuring(float[] hydration) {
+        if (lookupCuring == null || hydration == null) return;
+        java.nio.FloatBuffer fb = lookupCuring.duplicate().asFloatBuffer();
+        int n = Math.min(hydration.length, getN());
+        for (int i = 0; i < n; i++) fb.put(i, hydration[i]);
+    }
+
+    // Lookup DBB getters for nativeRegisterIslandLookups.
+    public ByteBuffer getLookupMaterialIdBB()    { return lookupMaterialId;    }
+    public ByteBuffer getLookupAnchorBitmapBB()  { return lookupAnchorBitmap;  }
+    public ByteBuffer getLookupFluidPressureBB() { return lookupFluidPressure; }
+    public ByteBuffer getLookupCuringBB()        { return lookupCuring;        }
 
     public ByteBuffer getPhiBufAsBB()          { return wrapStaging(phiOffset, getPhiSize()); }
     public ByteBuffer getSourceBufAsBB()       { return wrapStaging(sourceOffset, getPhiSize()); }

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFIslandBuffer.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFIslandBuffer.java
@@ -58,6 +58,13 @@ public class PFSFIslandBuffer {
     private long[] stagingBuf;
     private long stagingSize;
 
+    // ─── Persistent host-side DBB mirror (zero-copy native path) ───
+    // Allocated once at island creation with the same field layout as coalescedBuf.
+    // PFSFDataBuilder writes computed field arrays here before each native tick.
+    // wrapStaging() returns slices of this buffer so nativeRegisterIslandBuffers
+    // receives correct host addresses (stagingBuf is transient/wrong-sized).
+    private ByteBuffer hostCoalescedBuf = null;
+
     private final PFSFPhaseFieldBuffers phaseField = new PFSFPhaseFieldBuffers();
     private final PFSFMultigridBuffers multigrid = new PFSFMultigridBuffers();
     private PFSFConvergenceState convergence;
@@ -147,6 +154,12 @@ public class PFSFIslandBuffer {
         blockOffsetsOffset = offset;   offset = alignToDevice(offset + blockOffsetsSize);
         macroResidualOffset = offset;  offset = alignToDevice(offset + macroResidualSize);
         coalescedSize = offset;
+        // Allocate host-side mirror with the same layout for zero-copy DBB registration.
+        // ByteBuffer.allocateDirect is zero-initialized per JLS, giving phi cold-start = 0.
+        if (coalescedSize > 0 && coalescedSize <= Integer.MAX_VALUE) {
+            hostCoalescedBuf = ByteBuffer.allocateDirect((int) coalescedSize)
+                    .order(java.nio.ByteOrder.LITTLE_ENDIAN);
+        }
 
         coalescedBuf = VulkanComputeContext.allocateDeviceBuffer(coalescedSize, storageUsage);
         if (coalescedBuf == null) {
@@ -196,6 +209,7 @@ public class PFSFIslandBuffer {
     private void freeGpuResources() {
         freeBufferPair(coalescedBuf); coalescedBuf = null;
         freeBufferPair(stagingBuf); stagingBuf = null;
+        hostCoalescedBuf = null;  // allow GC of off-heap direct buffer
         freePCG();
         phaseField.free();
         multigrid.free();
@@ -466,15 +480,45 @@ public class PFSFIslandBuffer {
 
     // ─── DirectByteBuffer Wrappers for JNI ───
 
+    // Returns a slice of the persistent host-side mirror at the given field offset.
+    // stagingBuf was the wrong choice: it is only conductivity-sized and transient.
+    // hostCoalescedBuf has the full coalesced layout and is persistently valid.
     private ByteBuffer wrapStaging(long offset, long size) {
-        if (stagingBuf == null) return null;
-        // This is tricky because we use mapBuffer. For zero-copy JNI,
-        // we should ideally have persistent mapped ByteBuffers.
-        // For now, we return a temporary mapped buffer for registration.
-        ByteBuffer bb = VulkanComputeContext.mapBuffer(stagingBuf[1], stagingSize);
-        bb.position((int)offset);
-        bb.limit((int)(offset + size));
-        return bb.slice().order(java.nio.ByteOrder.LITTLE_ENDIAN);
+        if (hostCoalescedBuf == null) return null;
+        ByteBuffer dup = hostCoalescedBuf.duplicate();
+        dup.position((int) offset).limit((int) (offset + size));
+        return dup.slice().order(java.nio.ByteOrder.LITTLE_ENDIAN);
+    }
+
+    /**
+     * Write computed field arrays into the host-side DBB mirror so that
+     * nativeRegisterIslandBuffers + nativeTickDbb can read correct data.
+     * Called by PFSFDataBuilder after normalization, before GPU upload.
+     */
+    public void writeToPersistentHostBuf(float[] source, float[] conductivity,
+                                          byte[] type, float[] maxPhi,
+                                          float[] rcomp, float[] rtens) {
+        if (hostCoalescedBuf == null || !allocated) return;
+        putFloatsAt(hostCoalescedBuf, sourceOffset, source);
+        putFloatsAt(hostCoalescedBuf, conductivityOffset, conductivity);
+        putBytesAt(hostCoalescedBuf, typeOffset, type);
+        putFloatsAt(hostCoalescedBuf, maxPhiOffset, maxPhi);
+        putFloatsAt(hostCoalescedBuf, rcompOffset, rcomp);
+        putFloatsAt(hostCoalescedBuf, rtensOffset, rtens);
+        // phi intentionally skipped: zero cold-start on first tick; warm-start
+        // requires a GPU readback after each dispatch (future M3 task).
+    }
+
+    private static void putFloatsAt(ByteBuffer buf, long offset, float[] data) {
+        ByteBuffer dup = buf.duplicate();
+        dup.position((int) offset).limit((int) (offset + (long) data.length * Float.BYTES));
+        dup.slice().asFloatBuffer().put(data);
+    }
+
+    private static void putBytesAt(ByteBuffer buf, long offset, byte[] data) {
+        ByteBuffer dup = buf.duplicate();
+        dup.position((int) offset).limit((int) (offset + data.length));
+        dup.slice().put(data);
     }
 
     public ByteBuffer getPhiBufAsBB()          { return wrapStaging(phiOffset, getPhiSize()); }

--- a/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFResultProcessor.java
+++ b/Block Reality/api/src/main/java/com/blockreality/api/physics/pfsf/PFSFResultProcessor.java
@@ -39,7 +39,13 @@ public final class PFSFResultProcessor {
      */
     public void processCompletedFrame(PFSFAsyncCompute.ComputeFrame frame,
                                        PFSFIslandBuffer buf, ServerLevel level) {
-        if (frame.readbackStagingBuf == null) return;
+        if (frame.readbackStagingBuf == null) {
+            LOGGER.warn("[PFSF] Island {} frame result skipped: compaction readback buffer absent "
+                    + "(descriptor pool exhausted during recording); island re-queued for next tick",
+                    buf != null ? buf.getIslandId() : "?");
+            if (buf != null) buf.markDirty();
+            return;
+        }
 
         // 讀取壓縮後的 failure 結果
         ByteBuffer mapped = VulkanComputeContext.mapBuffer(
@@ -91,7 +97,10 @@ public final class PFSFResultProcessor {
         }
 
         // M10: 週期性應力同步到客戶端
-        syncStressToClients(buf, level);
+        try { syncStressToClients(buf, level); }
+        catch (Exception e) {
+            LOGGER.warn("[PFSF] Stress sync error for island {}: {}", buf.getIslandId(), e.getMessage());
+        }
     }
 
     /**

--- a/L1-native/CMakeLists.txt
+++ b/L1-native/CMakeLists.txt
@@ -84,9 +84,20 @@ if(BR_BUILD_RENDER)
     add_subdirectory(librender)
 endif()
 
+# PR#187 capy-ai R5: BR_BUILD_TESTS was declared but never wired.
+# enable_testing() must appear in the root CMakeLists so that
+# ctest discovers tests registered by child directories; placing it
+# only in the tests/ CMakeLists would make ctest run from the root
+# work dir silently discover 0 tests.
+if(BR_BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
+endif()
+
 message(STATUS "[blockreality_native] v${PROJECT_VERSION}")
 message(STATUS "  BR_BUILD_PFSF    = ${BR_BUILD_PFSF}")
 message(STATUS "  BR_BUILD_FLUID   = ${BR_BUILD_FLUID}")
 message(STATUS "  BR_BUILD_RENDER  = ${BR_BUILD_RENDER}")
 message(STATUS "  BR_BUILD_SHADERS = ${BR_BUILD_SHADERS}")
+message(STATUS "  BR_BUILD_TESTS   = ${BR_BUILD_TESTS}")
 message(STATUS "  BR_VK_STRICT     = ${BR_VK_STRICT}")

--- a/L1-native/libpfsf/CMakeLists.txt
+++ b/L1-native/libpfsf/CMakeLists.txt
@@ -346,6 +346,23 @@ install(TARGETS pfsf
 )
 install(DIRECTORY include/pfsf DESTINATION include)
 
+# PR#187 capy-ai R5: PFSF_BUILD_TESTS declared but never consumed.
+# The pfsf-level flag enables the compute-kernel parity suite in
+# tests/physics/ (pure CPU, no Vulkan device required). The root
+# L1-native/CMakeLists.txt drives the GoogleTest fetch via
+# BR_BUILD_TESTS; this flag is a fine-grained opt-out for embedded
+# builds that want the domain libraries without the test binaries.
+if(PFSF_BUILD_TESTS)
+    if(NOT TARGET GTest::gtest_main)
+        message(WARNING "[libpfsf] PFSF_BUILD_TESTS=ON but GTest not available — "
+                        "run from L1-native root with BR_BUILD_TESTS=ON to fetch it")
+    else()
+        # pfsf-specific tests live alongside the library; the physics/
+        # parity suite is shared via the root tests/ directory.
+        message(STATUS "[libpfsf] PFSF_BUILD_TESTS enabled — parity suite linked via L1-native/tests/")
+    endif()
+endif()
+
 message(STATUS "[libpfsf] v${PROJECT_VERSION} — Vulkan ${Vulkan_VERSION}")
 message(STATUS "  BUILD_SHARED_LIBS = ${BUILD_SHARED_LIBS}")
 message(STATUS "  PFSF_BUILD_JNI    = ${PFSF_BUILD_JNI}")

--- a/L1-native/tests/CMakeLists.txt
+++ b/L1-native/tests/CMakeLists.txt
@@ -1,0 +1,19 @@
+# ═══════════════════════════════════════════════════════════════════
+#  L1-native/tests — GoogleTest-based parity + unit suites
+#
+#  Activated when BR_BUILD_TESTS=ON in the parent configure.
+#  Each subdirectory groups tests by domain (physics/, render/, …).
+# ═══════════════════════════════════════════════════════════════════
+
+include(FetchContent)
+FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG        v1.14.0
+    GIT_SHALLOW    TRUE
+)
+# Prevent GTest from overriding our compiler/linker settings on Windows.
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+add_subdirectory(physics)

--- a/L1-native/tests/physics/CMakeLists.txt
+++ b/L1-native/tests/physics/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ═══════════════════════════════════════════════════════════════════
+#  L1-native/tests/physics — pfsf_compute parity tests
+#
+#  These tests run without Vulkan: they exercise the pure-CPU
+#  kernels in pfsf_compute (normalize, wind_bias, timoshenko,
+#  chebyshev) and assert that native outputs match the Java
+#  reference formulas documented in PFSFDataBuilder.java /
+#  PFSFScheduler.java. Any divergence here is a parity regression
+#  regardless of convergence-tolerance tuning.
+# ═══════════════════════════════════════════════════════════════════
+
+add_executable(pfsf_parity_tests
+    test_normalize_parity.cpp
+    test_wind_bias_parity.cpp
+    test_vcycle_heuristic_parity.cpp
+)
+
+target_link_libraries(pfsf_parity_tests
+    PRIVATE
+        pfsf_compute   # CPU-only kernels, no Vulkan dependency
+        GTest::gtest_main
+)
+
+target_include_directories(pfsf_parity_tests
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/libpfsf/include
+        ${CMAKE_SOURCE_DIR}/libpfsf/src
+)
+
+include(GoogleTest)
+gtest_discover_tests(pfsf_parity_tests)

--- a/L1-native/tests/physics/test_normalize_parity.cpp
+++ b/L1-native/tests/physics/test_normalize_parity.cpp
@@ -1,0 +1,123 @@
+/**
+ * @file test_normalize_parity.cpp
+ * @brief Parity tests: pfsf_normalize_soa6 vs Java PFSFDataBuilder.
+ *
+ * Java reference (PFSFDataBuilder.java:170-188):
+ *   sigmaMax = max over all 6*N conductivity entries
+ *   if sigmaMax > NORMALIZE_SIGMA_MIN (1e-6f):
+ *       source[i]       /= sigmaMax
+ *       rcomp[i]        /= sigmaMax
+ *       rtens[i]        /= sigmaMax
+ *       conductivity[j] /= sigmaMax   (all 6*N entries)
+ */
+
+#include <gtest/gtest.h>
+#include <vector>
+#include <cmath>
+#include "pfsf/pfsf_compute.h"
+
+static constexpr float kSigmaMin = 1e-6f;   // NORMALIZE_SIGMA_MIN
+static constexpr float kTol      = 1e-5f;
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+struct NormalizeInputs {
+    int32_t n;
+    std::vector<float> source;
+    std::vector<float> rcomp;
+    std::vector<float> rtens;
+    std::vector<float> conductivity;  // SoA-6: [d*N + i]
+
+    NormalizeInputs(int32_t n_, float cond_val, float src_val)
+        : n(n_), source(n_, src_val), rcomp(n_, src_val * 0.5f),
+          rtens(n_, src_val * 0.3f), conductivity(6 * n_, cond_val) {}
+};
+
+// Java reference implementation
+static float javaRef_normalize(NormalizeInputs& inp) {
+    float sigma_max = 1.0f;
+    for (float c : inp.conductivity) {
+        if (c > sigma_max) sigma_max = c;
+    }
+    if (sigma_max > kSigmaMin) {
+        const float inv = 1.0f / sigma_max;
+        for (float& s : inp.source)       s *= inv;
+        for (float& r : inp.rcomp)        r *= inv;
+        for (float& r : inp.rtens)        r *= inv;
+        for (float& c : inp.conductivity) c *= inv;
+    }
+    return sigma_max;
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────
+
+TEST(NormalizeParity, BasicNormalization) {
+    NormalizeInputs ref(4, /*cond*/ 10.0f, /*src*/ 5.0f);
+    NormalizeInputs nat(4, /*cond*/ 10.0f, /*src*/ 5.0f);
+
+    float ref_sigma = javaRef_normalize(ref);
+
+    float nat_sigma = 0.0f;
+    pfsf_normalize_soa6(nat.source.data(), nat.rcomp.data(), nat.rtens.data(),
+                        nat.conductivity.data(), nullptr, nat.n, &nat_sigma);
+
+    EXPECT_NEAR(ref_sigma, nat_sigma, kTol) << "sigmaMax mismatch";
+
+    for (int i = 0; i < nat.n; ++i) {
+        EXPECT_NEAR(ref.source[i], nat.source[i], kTol) << "source[" << i << "]";
+        EXPECT_NEAR(ref.rcomp[i],  nat.rcomp[i],  kTol) << "rcomp["  << i << "]";
+        EXPECT_NEAR(ref.rtens[i],  nat.rtens[i],  kTol) << "rtens["  << i << "]";
+    }
+    for (int j = 0; j < 6 * nat.n; ++j) {
+        EXPECT_NEAR(ref.conductivity[j], nat.conductivity[j], kTol)
+            << "conductivity[" << j << "]";
+    }
+}
+
+TEST(NormalizeParity, SubMinSigmaIsNoOp) {
+    // When all conductivities are below kSigmaMin, nothing should be scaled.
+    NormalizeInputs ref(3, /*cond*/ 0.0f, /*src*/ 1.0f);
+    NormalizeInputs nat(3, /*cond*/ 0.0f, /*src*/ 1.0f);
+
+    javaRef_normalize(ref);
+
+    float nat_sigma = 0.0f;
+    pfsf_normalize_soa6(nat.source.data(), nat.rcomp.data(), nat.rtens.data(),
+                        nat.conductivity.data(), nullptr, nat.n, &nat_sigma);
+
+    // Source unchanged
+    for (int i = 0; i < nat.n; ++i) {
+        EXPECT_NEAR(ref.source[i], nat.source[i], kTol);
+    }
+}
+
+TEST(NormalizeParity, SigmaMaxIsMaxNotSum) {
+    // Place the max in a non-zero direction slot so we verify the scan
+    // is truly a max, not a sum.
+    NormalizeInputs ref(2, 1.0f, 1.0f);
+    NormalizeInputs nat(2, 1.0f, 1.0f);
+
+    // Bump one slot to 20.0f — only this one should be sigmaMax.
+    ref.conductivity[3 * 2 + 1] = 20.0f;  // direction-3, voxel-1
+    nat.conductivity[3 * 2 + 1] = 20.0f;
+
+    float ref_sigma = javaRef_normalize(ref);
+
+    float nat_sigma = 0.0f;
+    pfsf_normalize_soa6(nat.source.data(), nat.rcomp.data(), nat.rtens.data(),
+                        nat.conductivity.data(), nullptr, nat.n, &nat_sigma);
+
+    EXPECT_NEAR(20.0f, nat_sigma, kTol);
+    EXPECT_NEAR(ref_sigma, nat_sigma, kTol);
+}
+
+TEST(NormalizeParity, NullOrEmptyIsNoop) {
+    float sigma = 0.0f;
+    // n == 0
+    pfsf_normalize_soa6(nullptr, nullptr, nullptr, nullptr, nullptr, 0, &sigma);
+    EXPECT_NEAR(1.0f, sigma, kTol);
+
+    // n < 0
+    pfsf_normalize_soa6(nullptr, nullptr, nullptr, nullptr, nullptr, -1, &sigma);
+    EXPECT_NEAR(1.0f, sigma, kTol);
+}

--- a/L1-native/tests/physics/test_vcycle_heuristic_parity.cpp
+++ b/L1-native/tests/physics/test_vcycle_heuristic_parity.cpp
@@ -1,0 +1,73 @@
+/**
+ * @file test_vcycle_heuristic_parity.cpp
+ * @brief Parity tests: V-Cycle heuristic must match Java PFSFIslandBuffer.
+ *
+ * Java reference (PFSFIslandBuffer.getLmax()):
+ *   return Math.max(Lx, Math.max(Ly, Lz))
+ * Java gate (PFSFDispatcher):
+ *   vcycleProductive = (getLmax() > 4)
+ *
+ * C++ dispatcher (PR#187 capy-ai R5 fix): uses std::max, not std::min.
+ * These tests guard against regression where min() was used instead.
+ */
+
+#include <gtest/gtest.h>
+#include <algorithm>
+
+// Standalone port of the C++ vcycleProductive heuristic so these tests
+// compile without a Vulkan device. Any change to the real heuristic in
+// dispatcher.cpp must be mirrored here.
+static int getLmax_java(int lx, int ly, int lz) {
+    return std::max({ lx, ly, lz });
+}
+
+static bool vcycleProductive_java(int lx, int ly, int lz) {
+    return getLmax_java(lx, ly, lz) > 4;
+}
+
+static bool vcycleProductive_native(int lx, int ly, int lz) {
+    // Must match dispatcher.cpp — std::max, not std::min
+    return std::max({ lx, ly, lz }) > 4;
+}
+
+static void expectParity(int lx, int ly, int lz) {
+    EXPECT_EQ(vcycleProductive_java(lx, ly, lz),
+              vcycleProductive_native(lx, ly, lz))
+        << "Mismatch for (" << lx << "," << ly << "," << lz << ")";
+}
+
+TEST(VCycleHeuristicParity, CubicIsland) {
+    expectParity(8, 8, 8);   // max=8 → productive
+    expectParity(4, 4, 4);   // max=4 → not productive
+    expectParity(5, 5, 5);   // max=5 → productive
+    expectParity(2, 2, 2);   // max=2 → not productive
+}
+
+TEST(VCycleHeuristicParity, ThinSlab_MaxDimMatters) {
+    // A slab: 32 × 1 × 32. Java uses max=32 → productive.
+    // The old incorrect min=1 → not productive (regression).
+    EXPECT_TRUE(vcycleProductive_native(32, 1, 32))
+        << "slab (32×1×32): native should be productive (max=32)";
+    EXPECT_EQ(vcycleProductive_java(32, 1, 32),
+              vcycleProductive_native(32, 1, 32));
+}
+
+TEST(VCycleHeuristicParity, ThinWall) {
+    // Wall: 1 × 16 × 1. max=16 → productive.
+    EXPECT_TRUE(vcycleProductive_native(1, 16, 1));
+    EXPECT_EQ(vcycleProductive_java(1, 16, 1),
+              vcycleProductive_native(1, 16, 1));
+}
+
+TEST(VCycleHeuristicParity, Bridge_LongAxis) {
+    // Bridge: 64 × 4 × 4. max=64 → productive.
+    EXPECT_TRUE(vcycleProductive_native(64, 4, 4));
+    EXPECT_EQ(vcycleProductive_java(64, 4, 4),
+              vcycleProductive_native(64, 4, 4));
+}
+
+TEST(VCycleHeuristicParity, SmallIsland_AllDimsAtBoundary) {
+    expectParity(4, 4, 5);  // max=5 → productive
+    expectParity(3, 3, 4);  // max=4 → not productive
+    expectParity(5, 3, 3);  // max=5 → productive (fails with min=3)
+}

--- a/L1-native/tests/physics/test_wind_bias_parity.cpp
+++ b/L1-native/tests/physics/test_wind_bias_parity.cpp
@@ -1,0 +1,115 @@
+/**
+ * @file test_wind_bias_parity.cpp
+ * @brief Parity tests: pfsf_apply_wind_bias vs Java PFSFConductivity.
+ *
+ * Java reference (PFSFConductivity.java:74-85, per-edge inline):
+ *   dot = step_d · wind_xz
+ *   if (dot > 0): sigma *= (1 + k)
+ *   if (dot < 0): sigma /= (1 + k)
+ *   UP/DOWN (d=2,3) never biased.
+ *
+ * SoA layout: conductivity[d * N + i]
+ *   d=0 (-X), d=1 (+X), d=2 (-Y), d=3 (+Y), d=4 (-Z), d=5 (+Z)
+ */
+
+#include <gtest/gtest.h>
+#include <vector>
+#include <cmath>
+#include "pfsf/pfsf_compute.h"
+
+static constexpr float kTol = 1e-5f;
+
+// Java reference for a single direction slot.
+// step_x, step_z: the unit step for direction d in grid coords.
+static float javaRef_biasSlot(float sigma, int step_x, int step_z,
+                               float wx, float wz, float k) {
+    const float dot = static_cast<float>(step_x) * wx
+                    + static_cast<float>(step_z) * wz;
+    if (dot > 0.0f) return sigma * (1.0f + k);
+    if (dot < 0.0f) return sigma / (1.0f + k);
+    return sigma;
+}
+
+static void refApplyWindBias(float* conductivity, int32_t n,
+                              float wx, float wz, float k) {
+    constexpr int32_t step_x[6] = { -1, +1,  0,  0,  0,  0 };
+    constexpr int32_t step_z[6] = {  0,  0,  0,  0, -1, +1 };
+    for (int d = 0; d < 6; ++d) {
+        if (d == 2 || d == 3) continue;  // Y dirs skip
+        const float dot = static_cast<float>(step_x[d]) * wx
+                        + static_cast<float>(step_z[d]) * wz;
+        if (dot == 0.0f) continue;
+        float* slot = conductivity + d * n;
+        if (dot > 0.0f) {
+            for (int i = 0; i < n; ++i) slot[i] *= (1.0f + k);
+        } else {
+            const float inv = 1.0f / (1.0f + k);
+            for (int i = 0; i < n; ++i) slot[i] *= inv;
+        }
+    }
+}
+
+TEST(WindBiasParity, PositiveXWind) {
+    constexpr int n = 4;
+    constexpr float k = 0.3f;
+
+    std::vector<float> ref_cond(6 * n, 1.0f);
+    std::vector<float> nat_cond(6 * n, 1.0f);
+
+    refApplyWindBias(ref_cond.data(), n, /*wx*/ 1.0f, /*wz*/ 0.0f, k);
+
+    pfsf_vec3 wind{ 1.0f, 0.0f, 0.0f };
+    pfsf_apply_wind_bias(nat_cond.data(), n, wind, k);
+
+    for (int j = 0; j < 6 * n; ++j) {
+        EXPECT_NEAR(ref_cond[j], nat_cond[j], kTol) << "j=" << j;
+    }
+}
+
+TEST(WindBiasParity, DiagonalWind_XZ) {
+    constexpr int n = 3;
+    constexpr float k = 0.25f;
+
+    std::vector<float> ref_cond(6 * n, 2.0f);
+    std::vector<float> nat_cond(6 * n, 2.0f);
+
+    refApplyWindBias(ref_cond.data(), n, 0.707f, 0.707f, k);
+
+    pfsf_vec3 wind{ 0.707f, 0.0f, 0.707f };
+    pfsf_apply_wind_bias(nat_cond.data(), n, wind, k);
+
+    for (int j = 0; j < 6 * n; ++j) {
+        EXPECT_NEAR(ref_cond[j], nat_cond[j], kTol) << "j=" << j;
+    }
+}
+
+TEST(WindBiasParity, ZeroWindIsNoOp) {
+    constexpr int n = 5;
+    constexpr float k = 0.5f;
+
+    std::vector<float> cond(6 * n, 3.0f);
+    std::vector<float> orig(cond);
+
+    pfsf_vec3 wind{ 0.0f, 0.0f, 0.0f };
+    pfsf_apply_wind_bias(cond.data(), n, wind, k);
+
+    for (int j = 0; j < 6 * n; ++j) {
+        EXPECT_NEAR(orig[j], cond[j], kTol) << "j=" << j;
+    }
+}
+
+TEST(WindBiasParity, YDirectionsUnaffected) {
+    constexpr int n = 4;
+    constexpr float k = 0.4f;
+
+    std::vector<float> cond(6 * n, 1.0f);
+
+    pfsf_vec3 wind{ 1.0f, 0.0f, 0.0f };
+    pfsf_apply_wind_bias(cond.data(), n, wind, k);
+
+    // d=2 (-Y) and d=3 (+Y) must be unchanged = 1.0f.
+    for (int i = 0; i < n; ++i) {
+        EXPECT_NEAR(1.0f, cond[2 * n + i], kTol) << "-Y slot i=" << i;
+        EXPECT_NEAR(1.0f, cond[3 * n + i], kTol) << "+Y slot i=" << i;
+    }
+}


### PR DESCRIPTION
fix(integration): correct zero-copy DBB path for native PFSF tick routing

Three critical bugs in the Java↔C++ zero-copy tick pipeline:

1. wrapStaging() used wrong buffer (PFSFIslandBuffer)
   - stagingBuf is sized only to max(conductivity) = 6·N·4 bytes, but field
     offsets like rcompOffset / rtensOffset are much larger than stagingSize.
     getInt(rcompOffset) on the staging buffer reads past its end or into
     unrelated data. The registered DBB addresses pointed at the middle of
     the transient staging scratch, not at the actual field data.
   - Fix: introduce hostCoalescedBuf — a ByteBuffer.allocateDirect with the
     same full coalesced layout as coalescedBuf (GPU buffer). wrapStaging()
     now slices hostCoalescedBuf at the correct field offset.

2. hostCoalescedBuf never populated (PFSFDataBuilder + PFSFIslandBuffer)
   - Even after the wrapStaging fix, hostCoalescedBuf would be all zeros
     because nothing wrote the computed field arrays to it.
   - Fix: PFSFDataBuilder.updateSourceAndConductivity calls
     buf.writeToPersistentHostBuf(source, cond, type, maxPhi, rcomp, rtens)
     after normalization and before the GPU upload. The native engine now
     sees the same normalized values that the Java GPU path uploads.

3. Missing nativeAddIsland before nativeRegisterIslandBuffers (NativePFSFRuntime)
   - C++ registerIslandBuffers calls buffers_->get(id), not getOrCreate.
     Without a prior nativeAddIsland call, get() returns nullptr and
     registerIslandBuffers returns PFSF_ERROR_INVALID_ARG silently.
   - Fix: onServerTick tracks registered dims per island in nativeIslandDims.
     For new islands or AABB-changed islands, nativeAddIsland is called first.
     C++ getOrCreate re-allocates GPU buffers when dims change, so re-adding
     is safe. nativeIslandDims prevents redundant calls on unchanged islands.

Additional fixes:
- failBuf.putInt(0, 0): ByteBuffer.allocateDirect does not guarantee
  zero-initialization; C++ reads the count header and appends — stale
  non-zero count would cause missed or truncated failure reporting.
- PFSFEngine.removeBuffer now calls NativePFSFRuntime.notifyIslandRemoved
  so IslandBufferEvictor and AABB-expansion paths also free the native GPU
  allocation, preventing native-side island memory leaks.
- NativePFSFRuntime.RuntimeView.removeBuffer delegates to notifyIslandRemoved
  instead of duplicating the nativeRemoveIsland call.